### PR TITLE
Limit joint windup for single IK solutions

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,3 +1,40 @@
-- git: {local-name: industrial_experimental, uri: 'https://github.com/ros-industrial/industrial_experimental.git', version: indigo-devel}
-- git: {local-name: motoman, uri: 'https://github.com/ros-industrial/motoman.git', version: kinetic-devel}
-- git: {local-name: motoman-experimental, uri: 'https://github.com/ros-industrial/motoman_experimental', version: kinetic-devel}
+- git:
+    local-name: industrial_experimental
+    uri: https://github.com/ros-industrial/industrial_experimental.git
+    version: indigo-devel
+- git:
+    local-name: motoman
+    uri: https://github.com/ros-industrial/motoman.git
+    version: kinetic-devel
+- git:
+    local-name: motoman-experimental
+    uri: https://github.com/ros-industrial/motoman_experimental.git
+    version: kinetic-devel
+- git:
+    local-name: moveit
+    uri: https://github.com/ros-planning/moveit.git
+    version: master
+- git:
+    local-name: geometry
+    uri: https://github.com/ros/geometry.git
+    version: melodic-devel
+- git:
+    local-name: geometry2
+    uri: https://github.com/ros/geometry2.git
+    version: melodic-devel
+- git:
+    local-name: geometric_shapes
+    uri: https://github.com/ros-planning/geometric_shapes.git
+    version: melodic-devel
+- git:
+    local-name: moveit_msgs
+    uri: https://github.com/ros-planning/moveit_msgs.git
+    version: melodic-devel
+- git:
+    local-name: moveit_visual_tools
+    uri: https://github.com/ros-planning/moveit_visual_tools.git
+    version: master
+- git:
+    local-name: rviz_visual_tools
+    uri: https://github.com/PickNikRobotics/rviz_visual_tools
+    version: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: required 
-dist: trusty 
-language: generic 
+sudo: required
+dist: trusty
+language: generic
 compiler:
   - gcc
 notifications:
@@ -13,5 +13,5 @@ env:
     - ROS_DISTRO="kinetic" UPSTREAM_WORKSPACE=file  ROSINSTALL_FILENAME=.travis.rosinstall
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
-script: 
+script:
   - source .ci_config/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ notifications:
     recipients:
       - shaun.edwards@gmail.com
 env:
+  global:
+    - CATKIN_CONFIG="--extend /opt/ros/kinetic --blacklist motoman_bmda3_support motoman_csda10f_moveit_config motoman_csda10f_support motoman_epx_support motoman_experimental motoman_gp12_support motoman_gp7_support motoman_gp8_support motoman_mh12_support motoman_mh50_support motoman_motomini_support motoman_mpl80_moveit_config motoman_mpl_support moveit_ros_planning_interface moveit_experimental moveit_planners_chomp moveit_setup_assistant moveit_ros_manipulation moveit_ros_visualization motoman_driver moveit_chomp_optimizer_adapter moveit_ros_warehouse moveit_planners_ompl moveit_ros_benchmarks moveit_ros_move_group motoman_sda10f_support motoman_sia10d_support motoman_sia10f_support motoman_sia20d_moveit_config motoman_sia20d_support motoman_sia5d_moveit_config motoman_sia5d_support motoman_sia5d_moveit_config test_tf2 --cmake-args -DCMAKE_BUILD_TYPE=Release"
   matrix:
     - ROS_DISTRO="kinetic" UPSTREAM_WORKSPACE=file  ROSINSTALL_FILENAME=.travis.rosinstall
 install:

--- a/README.md
+++ b/README.md
@@ -100,3 +100,16 @@ rostest moveit_simple motoman_mh5_utest.launch -r
 ```
 
 **NOTE:** Refresh the RobotModel by un-checking and re-checking the checkbox.
+
+
+## Quick Demo
+
+1. Launch the RViz visualizer
+```
+roslaunch moveit_simple test_display.launch
+```
+
+1. Launch the demo
+```
+roslaunch moveit_simple kuka_kr210_demo.launch
+```

--- a/README.md
+++ b/README.md
@@ -3,39 +3,100 @@
 ## Installation
 1. Clone repository into workspace [It doesn't have to be called moveit_simple_ws]
 ```
-mkdir moveit_simple_ws && cd moveit_simple_ws
-mkdir src && cd src
-catkin_init_workspace
+export CATKIN_WS=$HOME/moveit_simple_ws/
+mkdir -p $CATKIN_WS/src && cd $CATKIN_WS/src
 git clone -b kinetic-devel https://github.com/plusone-robotics/moveit_simple.git
 ```
 
-2. Source Dependencies
+2. Get Source Dependencies
 ```
+cd $CATKIN_WS/src && \
 wstool init . moveit_simple/.travis.rosinstall
-cd ..
 ```
 
-3. Package Dependencies
+3. Install Package Dependencies
 ```
+cd $CATKIN_WS && \
 rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
 ```
-
-4. Build
+4. Configure and Build
 ```
-catkin build --cmake-args -DCMAKE_BUILD_TYPE=Debug
-or
-catkin build --cmake-args -DCMAKE_BUILD_TYPE=Release
+cd $CATKIN_WS && \
+catkin init -w . && \
+catkin config --extend /opt/ros/$ROS_DISTRO \
+              --blacklist \
+                    motoman_bmda3_support \
+                    motoman_csda10f_moveit_config \
+                    motoman_csda10f_support \
+                    motoman_epx_support \
+                    motoman_experimental \
+                    motoman_gp12_support \
+                    motoman_gp7_support \
+                    motoman_gp8_support \
+                    motoman_mh12_support \
+                    motoman_mh50_support \
+                    motoman_motomini_support \
+                    motoman_mpl80_moveit_config \
+                    motoman_mpl_support \
+                    moveit_ros_planning_interface \
+                    moveit_experimental \
+                    moveit_planners_chomp \
+                    moveit_setup_assistant \
+                    moveit_ros_planning_interface \
+                    moveit_ros_manipulation \
+                    moveit_ros_visualization \
+                    motoman_driver \
+                    moveit_chomp_optimizer_adapter \
+                    moveit_ros_warehouse \
+                    moveit_planners_ompl \
+                    moveit_ros_perception \
+              --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+catkin build
+```
+**NOTE:** To use gdb with this project set `-DCMAKE_BUILD_TYPE=Debug` instead.
 
-source devel/setup.bash
+5. Source the Workspace
+```
+source $CATKIN_WS/devel/setup.bash
 ```
 
-## Running Tests with Rviz Visualization
+**NOTE:** Whenever you open a new terminal session, you should re-run the following commands:
+
+```
+export CATKIN_WS=$HOME/moveit_simple_ws/
+source $CATKIN_WS/devel/setup.bash
+```
+
+## Building and Running Tests
+
+Run the following steps from anywhere within `$CATKIN_WS`. (eg. `cd $CATKIN_WS`)
+
+1.  Run the MoveIt Simple Tests
+```
+catkin build moveit_simple --no-deps -i --catkin-make-args run_tests
+```
+
+1. Get test results:
+```
+catkin_test_results $CATKIN_WS/build/moveit_simple
+```
+
+### Run the Tests Using RViz as a Visualizer
+Open two terminals and set your environment variables appropriately.
+
+1. Launch the RViz visualizer in the first terminal
 ```
 roslaunch moveit_simple test_display.launch
-rostest moveit_simple <Test Name>_utest.launch -r
+```
 
-Example:
+2. Launch a test in the second terminal. (Be sure to substitute `<Test Name>` with either `motoman_mh5` or `kuka_kr210`)
+```
+rostest moveit_simple <Test Name>_utest.launch -r
+```
+
+Eg:
+```
 rostest moveit_simple motoman_mh5_utest.launch -r
 ```
 
-Refresh the RobotModel by un-checking and re-checking the checkbox.
+**NOTE:** Refresh the RobotModel by un-checking and re-checking the checkbox.

--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -72,6 +72,17 @@ add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_genparam)
 
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
+add_executable(
+  ${PROJECT_NAME}_trajectory_planner_demo
+  scripts/trajectory_planner_demo.cpp
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_trajectory_planner_demo
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+)
+
 if(CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
@@ -90,7 +101,7 @@ if(CATKIN_ENABLE_TESTING)
 
 endif()
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_trajectory_planner_demo
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})

--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -57,7 +57,7 @@ include_directories(
   ${EIGEN3_INCLUDE_DIRS}
 )
 
-add_library(${PROJECT_NAME} 
+add_library(${PROJECT_NAME}
   src/joint_lock_options.cpp
   src/joint_locker.cpp
   src/online_robot.cpp

--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(${PROJECT_NAME}
   src/online_robot.cpp
   src/point_types.cpp
   src/robot.cpp
+  src/conversions.cpp
 )
 
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(${PROJECT_NAME}
   src/online_robot.cpp
   src/point_types.cpp
   src/robot.cpp
+  src/trajectory_planner.cpp
   src/conversions.cpp
 )
 

--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning
   moveit_simple_msgs
   moveit_visual_tools
+  random_numbers
   roscpp
   rosparam_handler
   sensor_msgs
@@ -38,6 +39,7 @@ catkin_package(
     eigen_conversions
     geometry_msgs
     moveit_simple_msgs
+    random_numbers
     roscpp
     rosparam_handler
     sensor_msgs
@@ -99,6 +101,10 @@ if(CATKIN_ENABLE_TESTING)
   set(MOVEIT_SIMPLE_TEST_SRC_FILES test/moveit_simple_utest.cpp test/joint_locker.cpp test/joint_lock_options.cpp)
   catkin_add_gtest(moveit_simple_utest ${MOVEIT_SIMPLE_TEST_SRC_FILES})
   target_link_libraries(moveit_simple_utest ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+  set(TOOL_WINDUP_SRC_FILES test/tool_windup_utest.cpp test/tool_windup.cpp)
+  add_rostest_gtest(tool_windup_utest test/launch/tool_windup_utest.launch ${TOOL_WINDUP_SRC_FILES})
+  target_link_libraries(tool_windup_utest ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 endif()
 

--- a/moveit_simple/include/moveit_simple/conversions.h
+++ b/moveit_simple/include/moveit_simple/conversions.h
@@ -1,0 +1,45 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CONVERSIONS_H
+#define CONVERSIONS_H
+
+#include <trajectory_msgs/JointTrajectoryPoint.h>
+
+#include <moveit_simple/point_types.h>
+
+
+namespace moveit_simple
+{
+  /**
+   * @brief toJointTrajPtMsg - Converts native joint point (vector + time) to ROS joint
+   * trajectory point message type.
+   * @param joint_point
+   * @param time
+   * @return
+   */
+  trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const std::vector<double> &joint_point,
+    double time);
+
+  trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const JointTrajectoryPoint &joint_point);
+
+  std::vector<moveit_simple::JointTrajectoryPoint>
+  toJointTrajectoryPoint(std::vector<trajectory_msgs::JointTrajectoryPoint>& ros_joint_trajectory_points);
+
+} // namespace moveit_simple
+#endif // CONVERSIONS_H

--- a/moveit_simple/include/moveit_simple/exceptions.h
+++ b/moveit_simple/include/moveit_simple/exceptions.h
@@ -50,12 +50,12 @@ public:
 class IKFailException : public std::runtime_error
 {
 public:
-  IKFailException(const std::string errorDescription) 
+  IKFailException(const std::string errorDescription)
     : std::runtime_error(errorDescription) { }
 };
 
 /**
- * @brief IKSolverTransformException: 
+ * @brief IKSolverTransformException:
  *
  * This inherits from std::runtime_error.
  * This is an exception class to be thrown when a custom iksolver is
@@ -78,12 +78,12 @@ public:
 class CollisionDetected : public std::runtime_error
 {
 public:
-  CollisionDetected(const std::string errorDescription) 
+  CollisionDetected(const std::string errorDescription)
     : std::runtime_error(errorDescription) { }
 };
 
 /**
- * @brief JointSeedException: 
+ * @brief JointSeedException:
  *
  * This inherits from std::runtime_error.
  * This is an exception class to be thrown when a pre-defined joint
@@ -93,7 +93,7 @@ public:
 class JointSeedException : public std::runtime_error
 {
 public:
-  JointSeedException(const std::string error_description) 
+  JointSeedException(const std::string error_description)
     : std::runtime_error(error_description) { }
 };
 } // namespace moveit_simple

--- a/moveit_simple/include/moveit_simple/exceptions.h
+++ b/moveit_simple/include/moveit_simple/exceptions.h
@@ -96,5 +96,20 @@ public:
   JointSeedException(const std::string error_description)
     : std::runtime_error(error_description) { }
 };
+
+/**
+ * @brief InvalidTrajectoryException
+ *
+ * This inherits from std::runtime_error.
+ * This is an exception class to be thrown when a trajectory
+ * contains invalid waypoints, i.e. joint states are out of
+ * bounds or time stamps are not achievable.
+ */
+class InvalidTrajectoryException : public std::runtime_error
+{
+public:
+  InvalidTrajectoryException(const std::string error_description)
+    : std::runtime_error(error_description) { }
+};
 } // namespace moveit_simple
 #endif // EXCEPTIONS_H

--- a/moveit_simple/include/moveit_simple/online_robot.h
+++ b/moveit_simple/include/moveit_simple/online_robot.h
@@ -40,7 +40,7 @@ class OnlineRobot : public Robot
 public:
   /**
   * @brief Constructor
-  */  
+  */
   OnlineRobot(const ros::NodeHandle &nh, const std::string &robot_description,
     const std::string &group_name);
 
@@ -51,7 +51,7 @@ public:
   * some tcp frame.
   */
   OnlineRobot(const ros::NodeHandle &nh, const std::string &robot_description,
-    const std::string &group_name, const std::string &ik_base_frame, 
+    const std::string &group_name, const std::string &ik_base_frame,
     const std::string &ik_tip_frame);
 
   /**

--- a/moveit_simple/include/moveit_simple/online_robot.h
+++ b/moveit_simple/include/moveit_simple/online_robot.h
@@ -59,23 +59,26 @@ public:
    * @param traj_name - name of trajectory to be executed (must be filled with
    * prior calls to "addTrajPoint".
    * @param collision_check - bool to turn check for collision on\off
+   * @param retime_trajectory - bool to fix trajectory timesteps if necessary on\off
    * @throws <moveit_simple::ExecutionFailureException> (Execution failure)
    * @throws <moveit_simple::IKFailException> (Conversion to joint trajectory failed)
    * @throws <std::invalid_argument> (Trajectory "traj_name" not found)
    * @throws <moveit_simple::CollisionDetected> (One of interpolated point is
    * in Collision with itself or environment)
    */
-  void execute(const std::string traj_name, bool collision_check = false);
+  void execute(const std::string traj_name, bool collision_check = false, bool retime_trajectory = false);
 
   /**
    * @brief execute a given planned joint trajectory
    * @param goal - Joint Trajectory goal which is a known 'Plan'
    * @param collision_check - bool to turn check for collision on\off
+   * @param retime_trajectory - bool to fix trajectory timesteps if necessary on\off
    * @throws <moveit_simple::ExecutionFailureException> (Execution failure)
    * @throws <moveit_simple::CollisionDetected> (One of interpolated point is
    * in Collision with itself or environment)
    */
-  void execute(std::vector<moveit_simple::JointTrajectoryPoint> &goal, bool collision_check = false);
+  void execute(std::vector<moveit_simple::JointTrajectoryPoint> &goal, bool collision_check = false,
+               bool retime_trajectory = false);
 
   /**
    * @brief Starts execution for a given trajectory, non blocking

--- a/moveit_simple/include/moveit_simple/point_types.h
+++ b/moveit_simple/include/moveit_simple/point_types.h
@@ -58,7 +58,7 @@ typedef std::vector<TrajectoryPointInfo> TrajectoryInfo;
 
 class TrajectoryPoint
 {
-public: 
+public:
   friend class Robot;
 
   virtual ~TrajectoryPoint() { }
@@ -112,7 +112,7 @@ class JointTrajectoryPoint : public TrajectoryPoint
 public:
   friend class CombinedTrajectoryPoint;
   JointTrajectoryPoint() : TrajectoryPoint("", 0.0, PointType::JOINT) { }
-  
+
   virtual ~JointTrajectoryPoint() { }
 
   JointTrajectoryPoint(std::vector<double> &joint_point, double t, std::string name = std::string(),
@@ -196,7 +196,7 @@ public:
   {
     return pose_;
   }
-  
+
   const std::vector<double> &jointPoint() const
   {
     return joint_point_;
@@ -210,7 +210,7 @@ public:
   std::string pointVecToString(const std::vector<double> &vec) const;
 
 protected:
-  
+
   virtual std::unique_ptr<JointTrajectoryPoint>
   toJointTrajPoint(const Robot &robot, double timeout, const std::vector<double> &seed,
                    JointLockOptions options = JointLockOptions::LOCK_NONE) const;

--- a/moveit_simple/include/moveit_simple/point_types.h
+++ b/moveit_simple/include/moveit_simple/point_types.h
@@ -143,13 +143,13 @@ public:
   friend class CombinedTrajectoryPoint;
   CartTrajectoryPoint() : TrajectoryPoint("", 0.0, PointType::CARTESIAN) { }
 
-  CartTrajectoryPoint(const Eigen::Affine3d pose, const double t, std::string name = std::string(),
+  CartTrajectoryPoint(const Eigen::Isometry3d pose, const double t, std::string name = std::string(),
                       JointLockOptions options = JointLockOptions::LOCK_NONE)
     : TrajectoryPoint(name, t, PointType::CARTESIAN, options), pose_(pose) { }
 
   virtual ~CartTrajectoryPoint() { }
 
-  const Eigen::Affine3d &pose() const
+  const Eigen::Isometry3d &pose() const
   {
     return pose_;
   }
@@ -161,7 +161,7 @@ protected:
   virtual std::unique_ptr<CartTrajectoryPoint> toCartTrajPoint(const Robot &robot) const;
 
 private:
-  Eigen::Affine3d pose_;
+  Eigen::Isometry3d pose_;
 };
 
 class CombinedTrajectoryPoint : public TrajectoryPoint
@@ -177,7 +177,7 @@ public:
   {
   }
 
-  CombinedTrajectoryPoint(std::vector<double> &joint_point, const Eigen::Affine3d pose, double t, double tol,
+  CombinedTrajectoryPoint(std::vector<double> &joint_point, const Eigen::Isometry3d pose, double t, double tol,
                           std::string name = std::string(), PointPreference type = PointPreference::JOINT,
                           JointLockOptions options = JointLockOptions::LOCK_NONE, double timeout = 5.0)
     : TrajectoryPoint(name, t, (type == PointPreference::JOINT) ? PointType::JOINT : PointType::CARTESIAN, options)
@@ -195,7 +195,7 @@ public:
     return options_;
   }
 
-  const Eigen::Affine3d &pose() const
+  const Eigen::Isometry3d &pose() const
   {
     return pose_;
   }
@@ -226,7 +226,7 @@ private:
 
   JointLockOptions options_;
   std::vector<double> joint_point_;
-  Eigen::Affine3d pose_;
+  Eigen::Isometry3d pose_;
   double tol_;
   double timeout_;
 };

--- a/moveit_simple/include/moveit_simple/point_types.h
+++ b/moveit_simple/include/moveit_simple/point_types.h
@@ -30,6 +30,7 @@
 namespace moveit_simple
 {
 class Robot;
+class TrajectoryPlanner;
 class TrajectoryPoint;
 class JointTrajectoryPoint;
 class CartTrajectoryPoint;
@@ -60,6 +61,8 @@ class TrajectoryPoint
 {
 public:
   friend class Robot;
+  friend class TrajectoryPlanner;
+
 
   virtual ~TrajectoryPoint() { }
 

--- a/moveit_simple/include/moveit_simple/prettyprint.hpp
+++ b/moveit_simple/include/moveit_simple/prettyprint.hpp
@@ -89,7 +89,7 @@ namespace pretty_print
     struct delimiters
     {
         using type = delimiters_values<TChar>;
-        static const type values; 
+        static const type values;
     };
 
 

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -435,6 +435,12 @@ public:
    */
   double getSpeedModifier(void) const;
 
+  void limitJointWindup(bool enabled);
+
+  bool setIKSeedStateFractions(const std::map<size_t, double>& ik_seed_state_fractions);
+
+  std::map<size_t, double> getIKSeedStateFractions() const;
+
   void updateRvizRobotState(const Eigen::Isometry3d &pose, const std::string &in_frame,
     const std::string &joint_seed, double timeout = 10.0) const;
 
@@ -557,10 +563,10 @@ protected:
   virtual std::vector<double> getJointState(void) const;
 
   bool getIK(const Eigen::Isometry3d pose, const std::vector<double> &seed,
-    std::vector<double> &joint_point, double timeout = 1) const;
+    std::vector<double> &joint_point, double timeout = 1, bool limit_joint_windup = false) const;
 
   bool getIK(const Eigen::Isometry3d pose, std::vector<double> &joint_point,
-    double timeout = 1) const;
+    double timeout = 1, bool limit_joint_windup = false) const;
 
   bool getFK(const std::vector<double> &joint_point, Eigen::Isometry3d &pose) const;
 
@@ -613,6 +619,10 @@ protected:
 
   std::string planning_group_;
   std::string robot_description_;
+
+  // Limit IK joint windup
+  bool limit_joint_windup_;
+  std::map<size_t, double> ik_seed_state_fractions_;
 };
 } // namespace moveit_simple
 #endif // ROBOT_H

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -83,7 +83,7 @@ public:
    * @param timeout - (optional) timeout for IK
    * @return
    */
-  bool isInCollision(const Eigen::Affine3d &pose, const std::string &frame,
+  bool isInCollision(const Eigen::Isometry3d &pose, const std::string &frame,
     const std::string &joint_seed, double timeout = 10.0) const;
 
   /**
@@ -95,7 +95,7 @@ public:
    * @param timeout - (optional) timeout for IK
    * @return
    */
-  bool isInCollision(const Eigen::Affine3d &pose,
+  bool isInCollision(const Eigen::Isometry3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     const std::string &joint_seed, double timeout = 10.0) const;
 
@@ -109,7 +109,7 @@ public:
    * @param timeout - (optional) timeout for IK
    * @return
    */
-  bool isInCollision(const Eigen::Affine3d &pose,
+  bool isInCollision(const Eigen::Isometry3d &pose,
                      const geometry_msgs::TransformStamped &frame_to_robot_base,
                      const geometry_msgs::TransformStamped &custom_tool_to_moveit_tool,
                      const std::string &joint_seed, double timeout = 10.0) const;
@@ -132,7 +132,7 @@ public:
    * @param joint_seed (optional) - seed to use
    * @return
    */
-  bool isInCollision(const Eigen::Affine3d &pose, const std::string &frame,
+  bool isInCollision(const Eigen::Isometry3d &pose, const std::string &frame,
     double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
   /**
@@ -144,7 +144,7 @@ public:
    * @param joint_seed (optional) - seed to use
    * @return
    */
-  bool isInCollision(const Eigen::Affine3d &pose,
+  bool isInCollision(const Eigen::Isometry3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
@@ -166,7 +166,7 @@ public:
    * @param joint_seed - seed to use
    * @return
    */
-  bool isReachable(const Eigen::Affine3d &pose, const std::string &frame,
+  bool isReachable(const Eigen::Isometry3d &pose, const std::string &frame,
     const std::string &joint_seed, double timeout = 10.0) const;
 
   /**
@@ -177,7 +177,7 @@ public:
   * @param joint_seed - seed to use
   * @return
   */
-  bool isReachable(const Eigen::Affine3d &pose,
+  bool isReachable(const Eigen::Isometry3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     const std::string &joint_seed, double timeout = 10.0) const;
 
@@ -190,7 +190,7 @@ public:
   * @param joint_seed - seed to use
   * @return
   */
-  bool isReachable(const Eigen::Affine3d &pose,
+  bool isReachable(const Eigen::Isometry3d &pose,
                    const geometry_msgs::TransformStamped &frame_to_robot_base,
                    const geometry_msgs::TransformStamped &custom_tool_to_moveit_tool,
                    const std::string &joint_seed,
@@ -204,7 +204,7 @@ public:
    * @param joint_seed (optional) - named seed to use defined in srdf
    * @return
    */
-  bool isReachable(const Eigen::Affine3d &pose, const std::string &frame,
+  bool isReachable(const Eigen::Isometry3d &pose, const std::string &frame,
     double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
   /**
@@ -215,7 +215,7 @@ public:
    * @param joint_seed (optional) - named seed to use defined in srdf
    * @return
    */
-  bool isReachable(const Eigen::Affine3d &pose,
+  bool isReachable(const Eigen::Isometry3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
@@ -248,7 +248,7 @@ public:
    * @param point_name - (optional) name of point (used in log messages)
    * @throws <tf2::TransformException> (Transform from frame to robot base failed)
   */
-  void addTrajPoint(const std::string &traj_name, const Eigen::Affine3d pose,
+  void addTrajPoint(const std::string &traj_name, const Eigen::Isometry3d pose,
     const std::string &frame, double time, const InterpolationType &type = interpolation_type::JOINT,
     const unsigned int num_steps = 0, const std::string &point_name = std::string());
 
@@ -285,7 +285,7 @@ public:
    * @param point_name - (optional) name of point (used in log messages)
    * @throws <tf2::TransformException> (Transform from frame to robot base failed)
   */
-  void addTrajPoint(const std::string &traj_name, const Eigen::Affine3d pose,
+  void addTrajPoint(const std::string &traj_name, const Eigen::Isometry3d pose,
     const std::string &pose_frame, const std::string &tool_name, double time,
     const InterpolationType &type = interpolation_type::JOINT, const unsigned int num_steps = 0,
     const std::string &point_name = std::string());
@@ -323,7 +323,7 @@ public:
    * @param options - (optional) - Locks the joints when moving from the previous point
    * @throws <tf2::TransformException> (Transform from frame to robot base failed)
   */
-  void addTrajPointJointLock(const std::string &traj_name, const Eigen::Affine3d pose,
+  void addTrajPointJointLock(const std::string &traj_name, const Eigen::Isometry3d pose,
     const std::string &pose_frame, const std::string &tool_name, double time,
     const InterpolationType &type = interpolation_type::JOINT, const unsigned int num_steps = 0,
     const std::string &point_name = std::string(), JointLockOptions options = JointLockOptions::LOCK_NONE);
@@ -332,12 +332,11 @@ public:
    * @brief getJointSolution returns joint solution for cartesian pose.
    * @param pose - desired pose
    * @param timeout - ik solver timeout
-   * @param attempts - number of IK solve attem
    * @param seed - ik seed
    * @param joint_point - joint solution for pose
    * @return true if joint solution found
    */
-  bool getJointSolution(const Eigen::Affine3d &pose, double timeout, const std::vector<double> &seed,
+  bool getJointSolution(const Eigen::Isometry3d &pose, double timeout, const std::vector<double> &seed,
     std::vector<double> &joint_point) const;
 
   /**
@@ -346,12 +345,11 @@ public:
    * @param pose - desired pose
    * @param tool_name - frame (must be a TF accessible frame) in which pose is defined
    * @param timeout - ik solver timeout
-   * @param attempts - number of IK solve attem
    * @param seed - ik seed
    * @param joint_point - joint solution for pose
    * @return true if joint solution found
    */
-  bool getJointSolution(const Eigen::Affine3d &pose, const std::string &tool_name,
+  bool getJointSolution(const Eigen::Isometry3d &pose, const std::string &tool_name,
     double timeout, const std::vector<double> &seed, std::vector<double> &joint_point) const;
 
   /**
@@ -360,7 +358,7 @@ public:
    * @param pose - pose corresponding to joint_pose
    * @return true if pose is found
    */
-  bool getPose(const std::vector<double> &joint_point, Eigen::Affine3d &pose) const;
+  bool getPose(const std::vector<double> &joint_point, Eigen::Isometry3d &pose) const;
 
   /**
    * @brief getPose finds cartesian pose for the given joint positions.
@@ -371,7 +369,7 @@ public:
    * @return true if pose is found
    */
   bool getPose(const std::vector<double> &joint_point, const std::string &tool_name,
-    Eigen::Affine3d &pose) const;
+    Eigen::Isometry3d &pose) const;
 
   /**
    * @brief clearTrajectory - clears stored trajectory
@@ -400,7 +398,7 @@ public:
    * @param to: final pose
    * @param t: parameteric time
    */
-  Eigen::Affine3d interpolate(const Eigen::Affine3d &from, const Eigen::Affine3d &to,
+  Eigen::Isometry3d interpolate(const Eigen::Isometry3d &from, const Eigen::Isometry3d &to,
     double t) const;
 
   /**
@@ -437,17 +435,17 @@ public:
    */
   double getSpeedModifier(void) const;
 
-  void updateRvizRobotState(const Eigen::Affine3d &pose, const std::string &in_frame,
+  void updateRvizRobotState(const Eigen::Isometry3d &pose, const std::string &in_frame,
     const std::string &joint_seed, double timeout = 10.0) const;
 
-  void updateRvizRobotState(const Eigen::Affine3d &pose, const std::string &in_frame,
+  void updateRvizRobotState(const Eigen::Isometry3d &pose, const std::string &in_frame,
     std::vector<double> joint_seed = std::vector<double>(), double timeout = 10.0) const;
 
-  void updateRvizRobotState(const Eigen::Affine3d &pose,
+  void updateRvizRobotState(const Eigen::Isometry3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     const std::string &joint_seed, double timeout = 10.0) const;
 
-  void updateRvizRobotState(const Eigen::Affine3d &pose,
+  void updateRvizRobotState(const Eigen::Isometry3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     std::vector<double> joint_seed = std::vector<double>(),
     double timeout = 10.0) const;
@@ -462,9 +460,9 @@ public:
 protected:
   Robot();
 
-  Eigen::Affine3d transformToBase(const Eigen::Affine3d &in, const std::string &in_frame) const;
+  Eigen::Isometry3d transformToBase(const Eigen::Isometry3d &in, const std::string &in_frame) const;
 
-  Eigen::Affine3d transformToBase(const Eigen::Affine3d &in,
+  Eigen::Isometry3d transformToBase(const Eigen::Isometry3d &in,
     const geometry_msgs::TransformStamped &transform_msg) const;
 
   /**
@@ -474,7 +472,7 @@ protected:
    * @param frame_out - Target Frame of Reference for Transform
    * @param
    */
-  Eigen::Affine3d transformPoseBetweenFrames(const Eigen::Affine3d &target_pose,
+  Eigen::Isometry3d transformPoseBetweenFrames(const Eigen::Isometry3d &target_pose,
     const std::string &frame_in, const std::string &frame_out) const;
 
   control_msgs::FollowJointTrajectoryGoal toFollowJointTrajectoryGoal(
@@ -558,13 +556,13 @@ protected:
   */
   virtual std::vector<double> getJointState(void) const;
 
-  bool getIK(const Eigen::Affine3d pose, const std::vector<double> &seed,
-    std::vector<double> &joint_point, double timeout = 1, unsigned int attempts = 1) const;
+  bool getIK(const Eigen::Isometry3d pose, const std::vector<double> &seed,
+    std::vector<double> &joint_point, double timeout = 1) const;
 
-  bool getIK(const Eigen::Affine3d pose, std::vector<double> &joint_point,
-    double timeout = 1, unsigned int attempts = 1) const;
+  bool getIK(const Eigen::Isometry3d pose, std::vector<double> &joint_point,
+    double timeout = 1) const;
 
-  bool getFK(const std::vector<double> &joint_point, Eigen::Affine3d &pose) const;
+  bool getFK(const std::vector<double> &joint_point, Eigen::Isometry3d &pose) const;
 
   std::unique_ptr<TrajectoryPoint> lookupTrajectoryPoint(const std::string &name,
     double time) const;
@@ -610,8 +608,8 @@ protected:
   // Kinematics
   std::string ik_base_frame_;
   std::string ik_tip_frame_;
-  Eigen::Affine3d ik_tip_to_srdf_tip_;
-  Eigen::Affine3d srdf_base_to_ik_base_;
+  Eigen::Isometry3d ik_tip_to_srdf_tip_;
+  Eigen::Isometry3d srdf_base_to_ik_base_;
 
   std::string planning_group_;
   std::string robot_description_;

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -34,6 +34,7 @@
 
 #include <moveit_simple/moveit_simple_dynamic_reconfigure_Parameters.h>
 #include <moveit_simple/point_types.h>
+#include <moveit_simple/trajectory_planner.h>
 
 namespace moveit_simple
 {
@@ -48,6 +49,8 @@ namespace moveit_simple
 class Robot
 {
 public:
+  friend class TrajectoryPlanner;
+
   /**
   * @brief Constructor
   */
@@ -374,7 +377,8 @@ public:
    * @brief clearTrajectory - clears stored trajectory
    * @param traj_name - trajectory to clear
    */
-  void clearTrajectory(const ::std::string traj_name);
+  // TODO(mlautman): deprecate this
+  void clearTrajectory(const ::std::string& traj_name);
 
   /**
    * @brief plan out a given trajectory
@@ -476,6 +480,7 @@ protected:
   control_msgs::FollowJointTrajectoryGoal toFollowJointTrajectoryGoal(
     const std::vector<moveit_simple::JointTrajectoryPoint> &joint_trajectory_points) const;
 
+  // TODO(mlautman): Deprecate this
   bool toJointTrajectory(const std::string traj_name, std::vector<trajectory_msgs::JointTrajectoryPoint> &points,
     bool collision_check = false);
 
@@ -570,7 +575,7 @@ protected:
   void reconfigureRequest(moveit_simple_dynamic_reconfigure_Config &config, uint32_t level);
 
   // Robot internal objects
-  std::map<std::string, TrajectoryInfo> traj_info_map_;
+  TrajectoryPlanner trajectory_planner_;
 
   // MoveIt objects
   mutable moveit::core::RobotStatePtr virtual_robot_state_;  // for IK calls

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -641,7 +641,7 @@ protected:
   std::string robot_description_;
 
   // Limit IK joint windup
-  bool limit_joint_windup_;
+  bool limit_joint_windup_ = false;
   std::map<size_t, double> ik_seed_state_fractions_;
 };
 } // namespace moveit_simple

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -435,10 +435,30 @@ public:
    */
   double getSpeedModifier(void) const;
 
+  /**
+   * @brief limitJointWindup - Enable/Disable joint windup reduction in IK solutions by
+   * applying the seed state modifiers defined in ik_seed_state_fractions_. The fraction values
+   * are multiplied with the corresponding joint values in the seed state which causes IK solutions
+   * to be "pulled" towards the center. Additionally the modified joints are solved with a lower
+   * consistency_limit of PI. Both measures in combination act as a "soft" joint limit which doesn't
+   * affect the actual freedom of the joint but only centers IK solutions by a specified amount.
+   * @param enabled - Set joint windup limitation feature on/off
+   */
   void limitJointWindup(bool enabled);
 
+  /**
+   * @brief setIKSeedStateFractions - Specify joint value modifiers that should be applied in IK
+   * calls if joint windup limitation is enabled. On how to enable and use this feature see the function
+   * limitJointWindup() above.
+   * @param ik_seed_state_fractions - A map from joint ids to fraction values in range [0,1]
+   * @return true on success, false if invalid entries are found (invalid joint id, value out of range)
+   */
   bool setIKSeedStateFractions(const std::map<size_t, double>& ik_seed_state_fractions);
 
+  /**
+   * @brief getIKSeedStateFractions - Get the currently specified ik_seed_state_fractions_ map.
+   * @return ik_seed_state_fractions_
+   */
   std::map<size_t, double> getIKSeedStateFractions() const;
 
   void updateRvizRobotState(const Eigen::Isometry3d &pose, const std::string &in_frame,

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -473,9 +473,6 @@ protected:
   Eigen::Affine3d transformPoseBetweenFrames(const Eigen::Affine3d &target_pose,
     const std::string &frame_in, const std::string &frame_out) const;
 
-  std::vector<moveit_simple::JointTrajectoryPoint> toJointTrajectoryPoint(
-    std::vector<trajectory_msgs::JointTrajectoryPoint> &ROS_joint_trajectory_points) const;
-
   control_msgs::FollowJointTrajectoryGoal toFollowJointTrajectoryGoal(
     const std::vector<moveit_simple::JointTrajectoryPoint> &joint_trajectory_points) const;
 
@@ -568,18 +565,6 @@ protected:
     double time) const;
 
   bool isConfigChange(const std::vector<double> jp1, const std::vector<double> jp2) const;
-
-  /**
-   * @brief toJointTrajPtMsg - Converts native joint point (vector + time) to ROS joint
-   * trajectory point message type.
-   * @param joint_point
-   * @param time
-   * @return
-   */
-  static trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const std::vector<double> &joint_point,
-    double time);
-
-  trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const JointTrajectoryPoint &joint_point) const;
 
   // Dynamic Reconfigure callback
   void reconfigureRequest(moveit_simple_dynamic_reconfigure_Config &config, uint32_t level);

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -436,7 +436,7 @@ public:
   double getSpeedModifier(void) const;
 
   /**
-   * @brief limitJointWindup - Enable/Disable joint windup reduction in IK solutions by
+   * @brief setLimitJointWindup - Enable/Disable joint windup reduction in IK solutions by
    * applying the seed state modifiers defined in ik_seed_state_fractions_. The fraction values
    * are multiplied with the corresponding joint values in the seed state which causes IK solutions
    * to be "pulled" towards the center. Additionally the modified joints are solved with a lower
@@ -444,7 +444,12 @@ public:
    * affect the actual freedom of the joint but only centers IK solutions by a specified amount.
    * @param enabled - Set joint windup limitation feature on/off
    */
-  void limitJointWindup(bool enabled);
+  void setLimitJointWindup(bool enabled);
+
+  /**
+   * @brief getLimitJointWindup - query the robot class to determine if the limit_joint_windup_ flag is set
+   */
+  bool getLimitJointWindup();
 
   /**
    * @brief setIKSeedStateFractions - Specify joint value modifiers that should be applied in IK
@@ -583,10 +588,10 @@ protected:
   virtual std::vector<double> getJointState(void) const;
 
   bool getIK(const Eigen::Isometry3d pose, const std::vector<double> &seed,
-    std::vector<double> &joint_point, double timeout = 1, bool limit_joint_windup = false) const;
+    std::vector<double> &joint_point, double timeout = 1) const;
 
   bool getIK(const Eigen::Isometry3d pose, std::vector<double> &joint_point,
-    double timeout = 1, bool limit_joint_windup = false) const;
+    double timeout = 1) const;
 
   bool getFK(const std::vector<double> &joint_point, Eigen::Isometry3d &pose) const;
 
@@ -641,7 +646,7 @@ protected:
   std::string robot_description_;
 
   // Limit IK joint windup
-  bool limit_joint_windup_ = false;
+  bool limit_joint_windup_;
   std::map<size_t, double> ik_seed_state_fractions_;
 };
 } // namespace moveit_simple

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -50,7 +50,7 @@ class Robot
 public:
   /**
   * @brief Constructor
-  */  
+  */
   Robot(const ros::NodeHandle &nh, const std::string &robot_description,
     const std::string &group_name);
 
@@ -92,7 +92,7 @@ public:
    * @param timeout - (optional) timeout for IK
    * @return
    */
-  bool isInCollision(const Eigen::Affine3d &pose, 
+  bool isInCollision(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     const std::string &joint_seed, double timeout = 10.0) const;
 
@@ -141,7 +141,7 @@ public:
    * @param joint_seed (optional) - seed to use
    * @return
    */
-  bool isInCollision(const Eigen::Affine3d &pose, 
+  bool isInCollision(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
@@ -174,7 +174,7 @@ public:
   * @param joint_seed - seed to use
   * @return
   */
-  bool isReachable(const Eigen::Affine3d &pose, 
+  bool isReachable(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     const std::string &joint_seed, double timeout = 10.0) const;
 
@@ -212,7 +212,7 @@ public:
    * @param joint_seed (optional) - named seed to use defined in srdf
    * @return
    */
-  bool isReachable(const Eigen::Affine3d &pose, 
+  bool isReachable(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
@@ -439,11 +439,11 @@ public:
   void updateRvizRobotState(const Eigen::Affine3d &pose, const std::string &in_frame,
     std::vector<double> joint_seed = std::vector<double>(), double timeout = 10.0) const;
 
-  void updateRvizRobotState(const Eigen::Affine3d &pose, 
+  void updateRvizRobotState(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     const std::string &joint_seed, double timeout = 10.0) const;
 
-  void updateRvizRobotState(const Eigen::Affine3d &pose, 
+  void updateRvizRobotState(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     std::vector<double> joint_seed = std::vector<double>(),
     double timeout = 10.0) const;
@@ -460,7 +460,7 @@ protected:
 
   Eigen::Affine3d transformToBase(const Eigen::Affine3d &in, const std::string &in_frame) const;
 
-  Eigen::Affine3d transformToBase(const Eigen::Affine3d &in, 
+  Eigen::Affine3d transformToBase(const Eigen::Affine3d &in,
     const geometry_msgs::TransformStamped &transform_msg) const;
 
   /**
@@ -522,7 +522,7 @@ protected:
    * @param t: parameteric time
    * @param point: interpolated Cartesian point
    */
-  void interpolate(const std::unique_ptr<CartTrajectoryPoint> &from, 
+  void interpolate(const std::unique_ptr<CartTrajectoryPoint> &from,
     const std::unique_ptr<CartTrajectoryPoint> &to, double t,
     std::unique_ptr<CartTrajectoryPoint> &point) const;
 

--- a/moveit_simple/include/moveit_simple/trajectory_planner.h
+++ b/moveit_simple/include/moveit_simple/trajectory_planner.h
@@ -1,0 +1,131 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TRAJECTORY_PLANNER_H
+#define TRAJECTORY_PLANNER_H
+
+#include <mutex>
+
+#include <ros/ros.h>
+
+#include <moveit_simple/point_types.h>
+#include <moveit_simple/exceptions.h>
+
+#include <trajectory_msgs/JointTrajectoryPoint.h>
+
+
+namespace moveit_simple {
+class Robot;
+
+/**
+ * @brief TrajectoryPlanner manages the generation, lookup and planning of trajectories.
+ * Assumptions are:
+ *  - single arm manipulator (one joint group)
+ *  - all cartesian poses are of the tool of the robot (could be fixed in the future)
+ *  - point names are stored as joint positions in the SRDF or frame names in the
+ * URDF
+ * - frame transformations outside the URDF are provided by TF
+ */
+
+class TrajectoryPlanner {
+public:
+  /**
+  * @brief Constructor
+  */
+  TrajectoryPlanner()
+  {
+  }
+
+  /**
+  * @brief Destructor
+  */
+  ~TrajectoryPlanner(){}
+
+  void addTrajPoint(const std::string &traj_name, std::unique_ptr<TrajectoryPoint> &point,
+    const InterpolationType &type = interpolation_type::JOINT,
+    const unsigned int num_steps = 0);
+
+  /**
+   * @brief clearTrajectory - clears stored trajectory
+   * @param traj_name - trajectory to clear
+   */
+  void clearTrajectory(const ::std::string& traj_name);
+
+  /**
+   * @brief plan out a given trajectory
+   * @param robot - Robot to be used for planning
+   * @param traj_name - name of trajectory to be executed (must be filled with
+   * prior calls to "addTrajPoint".
+   * @param collision_check - bool to turn check for collision on\off
+   * @throws <moveit_simple::IKFailException> (Conversion to joint trajectory failed)
+   * @throws <std::invalid_argument> (Trajectory "traj_name" not found)
+   * @throws <moveit_simple::CollisionDetected> (One of interpolated point is
+   * in Collision with itself or environment)
+   */
+  std::vector<moveit_simple::JointTrajectoryPoint> plan(
+    Robot& robot,
+    const std::string traj_name, bool collision_check = false);
+
+  /**
+   * @brief  jointInterpolation - joint Interpolation from last added point to
+   * current trajectory point(traj_point).
+   * @param robot - Robot to be used for planning
+   * @param traj_point: target traj_point for joint interpolation
+   * @param points: Vector of Joint Trajectory Point to be executed. We append new points in place
+   *                This Vector must not be empty and it should have the current pose at index 0.
+   * @param num_steps: number of steps to be interpolated between current point and traj_point
+   * @param collision_check - bool to turn check for collision on\off
+   * @return true if all the points including traj_point are added to the points.
+   */
+  bool jointInterpolation(
+    Robot& robot,
+    const std::unique_ptr<TrajectoryPoint> &traj_point,
+    std::vector<trajectory_msgs::JointTrajectoryPoint> &points, const unsigned int num_steps,
+    bool collision_check = false);
+
+  /**
+   * @brief  cartesianInterpolation - Cartesian Interpolation from last added point to
+   * current trajectory point(traj_point).
+   * @param robot - Robot to be used for planning
+   * @param traj_point: target traj_point for cartesian interpolation
+   * @param points: Vector of Joint Trajectory Point to be executed
+   * @param num_steps: number of steps to be interpolated between current point and traj_point
+   * @param collision_check - bool to turn check for collision on\off
+   * @return true if all the points including traj_point are added to the points.
+   */
+  bool cartesianInterpolation(Robot& robot,
+    const std::unique_ptr<TrajectoryPoint> &traj_point,
+    std::vector<trajectory_msgs::JointTrajectoryPoint> &points, const unsigned int num_steps,
+    bool collision_check = false);
+
+
+  bool toJointTrajectory(
+    Robot& robot,
+    const std::string traj_name,
+    std::vector<trajectory_msgs::JointTrajectoryPoint> &points,
+    bool collision_check = false);
+
+
+  // Trajectory storage
+  std::map<std::string, TrajectoryInfo> traj_info_map_;
+  mutable std::recursive_mutex trajectory_info_map_mutex_;
+private:
+
+};
+} // namespace moveit_simple
+#endif // TRAJECTORY_PLANNER_H

--- a/moveit_simple/include/moveit_simple/trajectory_processing.h
+++ b/moveit_simple/include/moveit_simple/trajectory_processing.h
@@ -1,0 +1,137 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <moveit_simple/exceptions.h>
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
+#include <moveit/robot_state/robot_state.h>
+#include <moveit/robot_trajectory/robot_trajectory.h>
+
+#ifndef TRAJECTORY_PROCESSING_H
+#define TRAJECTORY_PROCESSING_H
+namespace moveit_simple
+{
+namespace trajectory_processing
+{
+struct TrajectoryValidationResult
+{
+  enum { Success,
+         InvalidPosition,
+         InvalidVelocity,
+         InvalidAcceleration,
+         InvalidTimestamp} value;
+  std::string error_message;
+};
+TrajectoryValidationResult validateTrajectory(robot_model::RobotModelConstPtr robot_model,
+                                              const trajectory_msgs::JointTrajectory& trajectory)
+{
+  TrajectoryValidationResult result;
+  const std::vector<std::string>& joint_names = trajectory.joint_names;
+  trajectory_msgs::JointTrajectoryPoint previous_point;
+  for (size_t i = 0; i < trajectory.points.size(); ++i)
+  {
+    // validate waypoint bounds
+    const auto& point = trajectory.points[i];
+    for (size_t j = 0; j < joint_names.size(); ++j)
+    {
+      const auto& joint_model = robot_model->getJointModel(joint_names[j]);
+      const auto& bounds = joint_model->getVariableBounds()[0];
+      // validate position bounds and throw exception since this can't be fixed easily
+      if (bounds.position_bounded_ && !joint_model->satisfiesPositionBounds(&point.positions[j]))
+      {
+        result.value = TrajectoryValidationResult::InvalidPosition;
+        result.error_message = "Trajectory invalidates position bounds in waypoint " + std::to_string(i) + " and joint "
+          + std::to_string(j);
+        return result;
+      }
+      // validate velocity/acceleration bounds and pair-wise time difference
+      double dt = (point.time_from_start - previous_point.time_from_start).toSec();
+      if (bounds.velocity_bounded_)
+      {
+        if (bounds.max_velocity_ < std::abs(point.velocities[j]))
+        {
+          result.value = TrajectoryValidationResult::InvalidVelocity;
+          result.error_message = "Trajectory invalidates velocity bounds in waypoint " + std::to_string(i)
+            + " and joint " + std::to_string(j);
+          return result;
+        }
+        if (i > 0 && bounds.max_velocity_ * dt < std::abs(point.positions[j] - previous_point.positions[j]))
+        {
+          result.value = TrajectoryValidationResult::InvalidVelocity;
+          result.error_message = "Position of trajectory waypoint " + std::to_string(i)
+            + " is not reachable given target time and velocity limits";
+          return result;
+        }
+      }
+      // validate acceleration bounds and pair-wise velocty difference
+      if (bounds.acceleration_bounded_)
+      {
+        if (bounds.max_acceleration_ < std::abs(point.accelerations[j]))
+        {
+          result.value = TrajectoryValidationResult::InvalidAcceleration;
+          result.error_message = "Trajectory invalidates acceleration bounds in waypoint " + std::to_string(i)
+            + " and joint " + std::to_string(j);
+          return result;
+        }
+        if (i > 0 && bounds.max_acceleration_ * dt < std::abs(point.velocities[j] - previous_point.velocities[j]))
+        {
+          result.value = TrajectoryValidationResult::InvalidAcceleration;
+          result.error_message = "Velocity of trajectory waypoint " + std::to_string(i) + " and joint "
+            + std::to_string(j) + " is not reachable given target time and acceleration limit";
+          return result;
+        }
+      }
+    }
+    previous_point = point;
+  }
+  result.value = TrajectoryValidationResult::Success;
+  return result;
+}
+
+void retimeTrajectory(robot_model::RobotModelConstPtr robot_model, const std::string& group_name,
+                      trajectory_msgs::JointTrajectory& joint_trajectory)
+{
+  // convert trajectory message to robot trajectory
+  robot_trajectory::RobotTrajectory trajectory(robot_model, group_name);
+  moveit::core::RobotState robot_state(robot_model);
+  trajectory.setRobotTrajectoryMsg(robot_state, joint_trajectory);
+  ::trajectory_processing::TimeOptimalTrajectoryGeneration totg;
+  if (!totg.computeTimeStamps(trajectory))
+    throw InvalidTrajectoryException("Failed to recompute trajectory time stamps");
+  moveit_msgs::RobotTrajectory trajectory_msg;
+  trajectory.getRobotTrajectoryMsg(trajectory_msg);
+  joint_trajectory = trajectory_msg.joint_trajectory;
+}
+
+void validateTrajectory(robot_model::RobotModelConstPtr robot_model,
+                        const std::string& group_name,
+                        trajectory_msgs::JointTrajectory& trajectory,
+                        bool retime_trajectory)
+{
+  TrajectoryValidationResult result = validateTrajectory(robot_model, trajectory);
+  if (result.value != TrajectoryValidationResult::Success)
+  {
+    // we can't fix invalid positions by trajectory parameterization
+    if (retime_trajectory && result.value != TrajectoryValidationResult::InvalidPosition)
+      retimeTrajectory(robot_model, group_name, trajectory);
+    else
+      throw InvalidTrajectoryException(result.error_message);
+  }
+}
+}  // namespace trajectory_processing
+}  // namespace moveit_simple
+#endif  // TRAJECTORY_PROCESSING_H

--- a/moveit_simple/launch/kuka_kr210_demo.launch
+++ b/moveit_simple/launch/kuka_kr210_demo.launch
@@ -23,6 +23,8 @@
     <arg name="run_test_node" value="$(arg run_test_node)"/>
   </include>
 
+  <node pkg="tf" type="static_transform_publisher" name="tfdummy" args="0 0 0 0 0 0 /world /base_link 10" />
+
   <!-- Test Node -->
   <node name="kuka_kr210_demo" pkg="moveit_simple" type="moveit_simple_trajectory_planner_demo"
   launch-prefix="$(arg launch_prefix)" />

--- a/moveit_simple/launch/kuka_kr210_demo.launch
+++ b/moveit_simple/launch/kuka_kr210_demo.launch
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- Unit test launch file -->
+  <!-- The name of the parameter under which the URDF is loaded -->
+  <arg name="robot_description" default="robot_description"/>
+
+  <!-- Launch test node -->
+  <arg name="run_test_node" default="true"/>
+
+  <!-- Debug Info -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <!-- Launch RViz -->
+  <include file="$(find moveit_simple)/test/launch/test_display.launch"/>
+
+  <!-- Launch Kuka -->
+  <include file="$(find moveit_simple)/test/launch/kuka_kr210.launch">
+    <arg name="robot_description" value="$(arg robot_description)"/>
+    <arg name="urdf_file" value="$(find moveit_simple)/test/resources/kuka_kr210/kr210l150.urdf"/>
+    <arg name="urdf_file_custom_tool" value="$(find moveit_simple)/test/resources/kuka_kr210/kuka_custom_tool.urdf"/>
+    <arg name="run_test_node" value="$(arg run_test_node)"/>
+  </include>
+
+  <!-- Test Node -->
+  <node name="kuka_kr210_demo" pkg="moveit_simple" type="moveit_simple_trajectory_planner_demo"
+  launch-prefix="$(arg launch_prefix)" />
+</launch>

--- a/moveit_simple/package.xml
+++ b/moveit_simple/package.xml
@@ -3,10 +3,10 @@
   <name>moveit_simple</name>
   <version>0.1.0</version>
   <description>Includes simple wrappers for calling MoveIt as a ROS based library.  Similar function as MoveGroup but all calls are made locally using direct MoveIt objects.  This library assumes that MoveIt is being used in a broader ROS system (i.e. certain parameters, like robot_description exist)</description>
-  
-  <license>Apache 2.0</license> <!-- moveit_simple --> 
+
+  <license>Apache 2.0</license> <!-- moveit_simple -->
   <license>Boost Software License</license> <!-- prettyprint -->
-  
+
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <author>Shaun Edwards</author>
 

--- a/moveit_simple/package.xml
+++ b/moveit_simple/package.xml
@@ -21,6 +21,7 @@
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>moveit_visual_tools</build_depend>
+  <build_depend>random_numbers</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rosparam_handler</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -39,6 +40,7 @@
   <run_depend>industrial_robot_simulator</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
+  <run_depend>random_numbers</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rosparam_handler</run_depend>

--- a/moveit_simple/scripts/trajectory_planner_demo.cpp
+++ b/moveit_simple/scripts/trajectory_planner_demo.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
                     (ros::NodeHandle(), "robot_description", "manipulator"));
 
   const std::string trajectory_name("traj1");
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+  const Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
   const moveit_simple::InterpolationType cart = moveit_simple::interpolation_type::CARTESIAN;
   const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
 

--- a/moveit_simple/scripts/trajectory_planner_demo.cpp
+++ b/moveit_simple/scripts/trajectory_planner_demo.cpp
@@ -43,6 +43,9 @@ int main(int argc, char **argv)
   robot->addTrajPoint(trajectory_name, "tf_pub1",   2.0, cart, 8);
   robot->addTrajPoint(trajectory_name, "waypoint2", 3.0);
   robot->addTrajPoint(trajectory_name, "waypoint3", 4.0, joint);
+  robot->addTrajPoint(trajectory_name, "waypoint1", 4.0, joint);
+  robot->addTrajPoint(trajectory_name, "waypoint3", 4.0, cart);
+  robot->addTrajPoint(trajectory_name, "waypoint1", 4.0, cart);
   robot->addTrajPoint(trajectory_name, pose, "tool0", 5.0);
 
   robot->execute(trajectory_name);

--- a/moveit_simple/scripts/trajectory_planner_demo.cpp
+++ b/moveit_simple/scripts/trajectory_planner_demo.cpp
@@ -1,0 +1,53 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ros/ros.h>
+
+#include <moveit_simple/moveit_simple.h>
+#include <moveit_simple/prettyprint.hpp>
+
+
+int main(int argc, char **argv)
+{
+  std::string name = "bin_pick_server_main";
+  ros::init(argc, argv, name);
+
+  ros::AsyncSpinner spinner(4);
+  spinner.start();
+
+  auto robot = std::unique_ptr<moveit_simple::OnlineRobot> (new moveit_simple::OnlineRobot
+                    (ros::NodeHandle(), "robot_description", "manipulator"));
+
+  const std::string trajectory_name("traj1");
+  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+  const moveit_simple::InterpolationType cart = moveit_simple::interpolation_type::CARTESIAN;
+  const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
+
+  robot->addTrajPoint(trajectory_name, "home",      0.5);
+  robot->addTrajPoint(trajectory_name, "waypoint1", 1.0, joint, 5);
+  robot->addTrajPoint(trajectory_name, "tf_pub1",   2.0, cart, 8);
+  robot->addTrajPoint(trajectory_name, "waypoint2", 3.0);
+  robot->addTrajPoint(trajectory_name, "waypoint3", 4.0, joint);
+  robot->addTrajPoint(trajectory_name, pose, "tool0", 5.0);
+
+  robot->execute(trajectory_name);
+
+  ros::waitForShutdown();
+  return 0;
+
+}

--- a/moveit_simple/src/conversions.cpp
+++ b/moveit_simple/src/conversions.cpp
@@ -1,0 +1,61 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <moveit_simple/conversions.h>
+
+
+namespace moveit_simple
+{
+  trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const std::vector<double> &joint_point,
+    double time)
+  {
+    trajectory_msgs::JointTrajectoryPoint rtn;
+    std::vector<double> empty(joint_point.size(), 0.0);
+
+    rtn.positions = joint_point;
+    rtn.velocities = empty;
+
+    rtn.accelerations = empty;
+    rtn.effort = empty;
+    rtn.time_from_start = ros::Duration(time);
+
+    return rtn;
+  }
+
+  trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const JointTrajectoryPoint &joint_point)
+  {
+    return toJointTrajPtMsg(joint_point.jointPoint(), joint_point.time());
+  }
+
+  std::vector<moveit_simple::JointTrajectoryPoint>
+  toJointTrajectoryPoint(std::vector<trajectory_msgs::JointTrajectoryPoint>& ros_joint_trajectory_points)
+  {
+    std::vector<moveit_simple::JointTrajectoryPoint> goal;
+    goal.reserve(ros_joint_trajectory_points.size());
+
+    for (std::size_t i = 0; i < ros_joint_trajectory_points.size(); i++)
+    {
+      JointTrajectoryPoint point(ros_joint_trajectory_points[i].positions,
+                                 ros_joint_trajectory_points[i].time_from_start.toSec(), "");
+      goal.push_back(point);
+    }
+
+    return goal;
+  }
+
+} // namespace moveit_simple

--- a/moveit_simple/src/online_robot.cpp
+++ b/moveit_simple/src/online_robot.cpp
@@ -25,6 +25,7 @@
 #include <moveit_simple/exceptions.h>
 #include <moveit_simple/online_robot.h>
 #include <moveit_simple/point_types.h>
+#include <moveit_simple/trajectory_processing.h>
 
 namespace moveit_simple
 {
@@ -76,7 +77,7 @@ OnlineRobot::OnlineRobot(const ros::NodeHandle &nh, const std::string &robot_des
   }
 }
 
-void OnlineRobot::execute(const std::string traj_name, bool collision_check)
+void OnlineRobot::execute(const std::string traj_name, bool collision_check, bool retime_trajectory)
 {
   std::lock_guard<std::recursive_mutex> guard(m_);
 
@@ -85,7 +86,7 @@ void OnlineRobot::execute(const std::string traj_name, bool collision_check)
     std::vector<moveit_simple::JointTrajectoryPoint> goal;
 
     goal = plan(traj_name, collision_check);
-    execute(goal);
+    execute(goal, false, retime_trajectory);
   }
   catch (IKFailException &ik)
   {
@@ -97,6 +98,11 @@ void OnlineRobot::execute(const std::string traj_name, bool collision_check)
     ROS_ERROR_STREAM("Collision detected in trajectory");
     throw cd;
   }
+  catch (InvalidTrajectoryException &ite)
+  {
+    ROS_ERROR_STREAM("Invalid trajectory [" << traj_name << "]: " << ite.what());
+    throw ite;
+  }
   catch (std::invalid_argument &ia)
   {
     ROS_ERROR_STREAM("Invalid trajectory name: [" << traj_name << "]");
@@ -104,19 +110,23 @@ void OnlineRobot::execute(const std::string traj_name, bool collision_check)
   }
   catch (ExecutionFailureException &ef)
   {
-    ROS_ERROR_STREAM("Trajectory [" << traj_name << "] failed to execute");
+    ROS_ERROR_STREAM("Trajectory [" << traj_name << "] failed to execute: " << ef.what());
     throw ef;
   }
 }
 
 void OnlineRobot::execute(std::vector<moveit_simple::JointTrajectoryPoint> &joint_trajectory_points,
-  bool collision_check)
+                          bool collision_check, bool retime_trajectory)
 {
   std::lock_guard<std::recursive_mutex> guard(m_);
 
   const double TIMEOUT_SCALE = 1.25;  // scales time to wait for action timeout.
 
   control_msgs::FollowJointTrajectoryGoal goal = toFollowJointTrajectoryGoal(joint_trajectory_points);
+
+  // validate trajectory waypoint bounds and timestamps
+  // if invalid, attempt to fix it or throw InvalidTrajectoryException
+  trajectory_processing::validateTrajectory(robot_model_ptr_, joint_group_->getName(), goal.trajectory, retime_trajectory);
 
   int collision_points = trajCollisionCheck(goal, collision_check);
 

--- a/moveit_simple/src/online_robot.cpp
+++ b/moveit_simple/src/online_robot.cpp
@@ -29,7 +29,7 @@
 namespace moveit_simple
 {
 OnlineRobot::OnlineRobot(const ros::NodeHandle &nh, const std::string &robot_description,
-  const std::string &group_name) : Robot(nh, robot_description, group_name), 
+  const std::string &group_name) : Robot(nh, robot_description, group_name),
   action_("joint_trajectory_action", true)
 {
   current_robot_state_.reset(new moveit::core::RobotState(robot_model_ptr_));
@@ -139,7 +139,7 @@ void OnlineRobot::execute(std::vector<moveit_simple::JointTrajectoryPoint> &join
   }
   else
   {
-    ROS_ERROR_STREAM("Collision detected at " << collision_points 
+    ROS_ERROR_STREAM("Collision detected at " << collision_points
       << " points for Joint Trajectory");
     throw CollisionDetected("Collision detected while interpolating ");
   }

--- a/moveit_simple/src/point_types.cpp
+++ b/moveit_simple/src/point_types.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<JointTrajectoryPoint> JointTrajectoryPoint::toJointTrajPoint(con
 
 std::unique_ptr<CartTrajectoryPoint> JointTrajectoryPoint::toCartTrajPoint(const Robot &robot) const
 {
-  Eigen::Affine3d pose;
+  Eigen::Isometry3d pose;
 
   ROS_DEBUG_STREAM("JointTrajectoryPoint: Calculating FK for Cartesian trajectory point");
   if (robot.getPose(joint_point_, pose))

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -32,6 +32,7 @@
 #include <moveit_simple/joint_locker.h>
 #include <moveit_simple/point_types.h>
 #include <moveit_simple/prettyprint.hpp>
+#include <moveit_simple/conversions.h>
 #include <moveit_simple/robot.h>
 
 namespace moveit_simple
@@ -886,22 +887,6 @@ std::vector<moveit_simple::JointTrajectoryPoint> Robot::plan(const std::string t
   }
 }
 
-std::vector<moveit_simple::JointTrajectoryPoint>
-Robot::toJointTrajectoryPoint(std::vector<trajectory_msgs::JointTrajectoryPoint>& ros_joint_trajectory_points) const
-{
-  std::vector<moveit_simple::JointTrajectoryPoint> goal;
-  goal.reserve(ros_joint_trajectory_points.size());
-
-  for (std::size_t i = 0; i < ros_joint_trajectory_points.size(); i++)
-  {
-    JointTrajectoryPoint point(ros_joint_trajectory_points[i].positions,
-                               ros_joint_trajectory_points[i].time_from_start.toSec(), "");
-    goal.push_back(point);
-  }
-
-  return goal;
-}
-
 control_msgs::FollowJointTrajectoryGoal Robot::toFollowJointTrajectoryGoal(
     const std::vector<moveit_simple::JointTrajectoryPoint>& joint_trajectory_points) const
 {
@@ -1569,26 +1554,6 @@ bool Robot::isNearSingular(const std::vector<double>& joint_point) const
                                                << " is not a chain");
     return false;
   }
-}
-
-trajectory_msgs::JointTrajectoryPoint Robot::toJointTrajPtMsg(const JointTrajectoryPoint& joint_point) const
-{
-  return toJointTrajPtMsg(joint_point.jointPoint(), joint_point.time());
-}
-
-trajectory_msgs::JointTrajectoryPoint Robot::toJointTrajPtMsg(const std::vector<double>& joint_point, double time)
-{
-  trajectory_msgs::JointTrajectoryPoint rtn;
-  std::vector<double> empty(joint_point.size(), 0.0);
-
-  rtn.positions = joint_point;
-  rtn.velocities = empty;
-
-  rtn.accelerations = empty;
-  rtn.effort = empty;
-  rtn.time_from_start = ros::Duration(time);
-
-  return rtn;
 }
 
 std::vector<double> Robot::getJointState(void) const

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -1251,14 +1251,15 @@ bool Robot::getIK(const Eigen::Isometry3d pose, std::vector<double>& joint_point
                   bool limit_joint_windup) const
 {
   Eigen::Isometry3d ik_tip_pose = pose * ik_tip_to_srdf_tip_;
-  std::vector<double> consistency_limit(6, 2 * M_PI);
+  std::vector<double> consistency_limit(6, 4 * M_PI);
   // we add a 'soft' consistency limit so that IK solutions can only converge slowly towards the joint limit
   if (limit_joint_windup && !ik_seed_state_fractions_.empty())
   {
     for (const std::pair<size_t, double>& seed_state_fraction : ik_seed_state_fractions_)
       consistency_limit[seed_state_fraction.first] = M_PI;
   }
-  if (virtual_robot_state_->setFromIK(joint_group_, ik_tip_pose, ik_tip_frame_, {consistency_limit}, timeout))
+  std::string ik_tip_frame = joint_group_->getSolverInstance()->getTipFrame();
+  if (virtual_robot_state_->setFromIK(joint_group_, ik_tip_pose, ik_tip_frame, {consistency_limit}, timeout))
   {
     virtual_robot_state_->copyJointGroupPositions(joint_group_->getName(), joint_point);
     virtual_robot_state_->update();

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -1252,7 +1252,7 @@ bool Robot::getIK(const Eigen::Isometry3d pose, std::vector<double>& joint_point
 {
   Eigen::Isometry3d ik_tip_pose = pose * ik_tip_to_srdf_tip_;
   std::vector<double> consistency_limit(6, 2 * M_PI);
-  // we add a 'soft' consistency limit that so that IK solutions can only converge slowly towards the joint limit
+  // we add a 'soft' consistency limit so that IK solutions can only converge slowly towards the joint limit
   if (limit_joint_windup && !ik_seed_state_fractions_.empty())
   {
     for (const std::pair<size_t, double>& seed_state_fraction : ik_seed_state_fractions_)

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -272,7 +273,7 @@ void Robot::addTrajPoint(const std::string& traj_name, const std::string& point_
 void Robot::addTrajPoint(const std::string& traj_name, std::unique_ptr<TrajectoryPoint>& point,
                          const InterpolationType& type, const unsigned int num_steps)
 {
-  traj_info_map_[traj_name].push_back({ std::move(point), type, num_steps });
+  trajectory_planner_.addTrajPoint(traj_name, point, type, num_steps);
 }
 
 void Robot::addTrajPointJointLock(const std::string& traj_name, const std::string& point_name, double time,
@@ -838,53 +839,14 @@ bool Robot::isReachable(std::unique_ptr<TrajectoryPoint>& point, double timeout,
   return reachable;
 }
 
-void Robot::clearTrajectory(const ::std::string traj_name)
+void Robot::clearTrajectory(const std::string& traj_name)
 {
-  std::lock_guard<std::recursive_mutex> guard(m_);
-  traj_info_map_.erase(traj_name);
+  trajectory_planner_.clearTrajectory(traj_name);
 }
 
 std::vector<moveit_simple::JointTrajectoryPoint> Robot::plan(const std::string traj_name, bool collision_check)
 {
-  std::lock_guard<std::recursive_mutex> guard(m_);
-
-  if (traj_info_map_.count(traj_name))
-  {
-    std::vector<trajectory_msgs::JointTrajectoryPoint> ROS_trajectory_points;
-
-    try
-    {
-      if (toJointTrajectory(traj_name, ROS_trajectory_points, collision_check))
-      {
-        // Modify the speed of execution for the trajectory based off of the speed_modifier_
-        for (std::size_t i = 0; i < ROS_trajectory_points.size(); i++)
-        {
-          ROS_trajectory_points[i].time_from_start *= (1.0 / speed_modifier_);
-        }
-
-        std::vector<moveit_simple::JointTrajectoryPoint> goal = toJointTrajectoryPoint(ROS_trajectory_points);
-
-        ROS_INFO_STREAM("Successfully planned out trajectory: [" << traj_name << "]");
-
-        return goal;
-      }
-      else
-      {
-        ROS_ERROR_STREAM("Failed to convert [" << traj_name << "] to joint trajectory");
-        throw IKFailException("Conversion to joint trajectory failed for " + traj_name);
-      }
-    }
-    catch (CollisionDetected& cd)
-    {
-      ROS_ERROR_STREAM("Collision detected in [" << traj_name << "]");
-      throw cd;
-    }
-  }
-  else
-  {
-    ROS_ERROR_STREAM("Trajectory [" << traj_name << "] not found");
-    throw std::invalid_argument("No trajectory found named " + traj_name);
-  }
+  return trajectory_planner_.plan(*this, traj_name, collision_check);
 }
 
 control_msgs::FollowJointTrajectoryGoal Robot::toFollowJointTrajectoryGoal(
@@ -970,49 +932,7 @@ double Robot::getSpeedModifier(void) const
 bool Robot::toJointTrajectory(const std::string traj_name, std::vector<trajectory_msgs::JointTrajectoryPoint>& points,
                               bool collision_check)
 {
-  const TrajectoryInfo& traj_info = traj_info_map_[traj_name];
-
-  // The first point in any trajectory is the current pose
-  std::vector<double> current_joint_position = getJointState();
-  points.push_back(toJointTrajPtMsg(current_joint_position, 0.0));
-
-  for (size_t i = 0; i < traj_info.size(); ++i)
-  {
-    const std::unique_ptr<TrajectoryPoint>& traj_point = traj_info[i].point;
-    if (traj_info[i].type == interpolation_type::JOINT)
-    {
-      if (jointInterpolation(traj_point, points, traj_info[i].num_steps, collision_check))
-      {
-        ROS_INFO_STREAM("Trajectory successfully added till " << traj_point->name());
-      }
-      else
-      {
-        ROS_ERROR_STREAM("Conversion to joint trajectory failed for " << traj_name << " due to IK failure of "
-                                                                      << traj_point->name());
-        return false;
-      }
-    }
-    else if (traj_info[i].type == interpolation_type::CARTESIAN)
-    {
-      if (cartesianInterpolation(traj_point, points, traj_info[i].num_steps, collision_check))
-      {
-        ROS_INFO_STREAM("Trajectory successfully added till " << traj_point->name());
-      }
-      else
-      {
-        ROS_ERROR_STREAM("Conversion to joint trajectory failed for " << traj_name << " before adding "
-                                                                      << traj_point->name());
-        return false;
-      }
-    }
-    else
-    {
-      ROS_ERROR_STREAM("Unknown interpolation call " << traj_info[i].type);
-      return false;
-    }
-  }
-
-  return true;
+  return trajectory_planner_.toJointTrajectory(*this, traj_name, points, collision_check);
 }
 
 void Robot::computeIKSolverTransforms()
@@ -1068,177 +988,14 @@ bool Robot::jointInterpolation(const std::unique_ptr<TrajectoryPoint>& traj_poin
                                std::vector<trajectory_msgs::JointTrajectoryPoint>& points, unsigned int num_steps,
                                bool collision_check)
 {
-  const double IK_TIMEOUT = 0.250;  // 250 ms for IK solving
-
-  auto options = traj_point->getJointLockOptions();
-
-  // Create a local vector for storing interpolated points
-  std::vector<trajectory_msgs::JointTrajectoryPoint> points_local;
-  trajectory_msgs::JointTrajectoryPoint prev_point_info = points.back();
-  std::vector<double> prev_point = prev_point_info.positions;
-  double prev_time = prev_point_info.time_from_start.toSec();
-
-  // Convert the previous point stored in points to Joint Trajectory Point
-  std::unique_ptr<JointTrajectoryPoint> prev_traj_point =
-      std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(prev_point, prev_time, ""));
-
-  std::unique_ptr<JointTrajectoryPoint> target_point;
-  if (traj_point->type() != TrajectoryPoint::JOINT)
-  {
-    const size_t MAX_IK_ATTEMPTS = 2;
-    size_t num_attempts = 0;
-
-    while (true)
-    {
-      num_attempts++;
-      target_point = traj_point->toJointTrajPoint(*this, IK_TIMEOUT, prev_point);
-
-      if (target_point)
-      {
-        if (isConfigChange(prev_point, target_point->jointPoint()))
-        {
-          ROS_WARN_STREAM("Configuration change detected in move to/from cart point: ("
-                          << traj_point->name() << "), of type: " << traj_point->type() << " to joint trajectory");
-        }
-        else
-        {
-          ROS_INFO_STREAM("Found proper IK (no config change) in " << num_attempts << " attempts");
-          break;
-        }
-      }
-      else
-      {
-        ROS_WARN_STREAM("Failed to convert trajectory point:  ("
-                        << traj_point->name() << "), of type: " << traj_point->type() << " to joint trajectory");
-        return false;
-      }
-      if (num_attempts >= MAX_IK_ATTEMPTS)
-      {
-        ROS_ERROR_STREAM("Failed to find proper IK (no config change) in " << num_attempts << " attempts");
-        return false;
-      }
-    }
-  }
-  else
-  {
-    target_point = traj_point->toJointTrajPoint(*this, IK_TIMEOUT, prev_point);
-    if (!target_point)
-    {
-      ROS_WARN_STREAM("Failed to convert joint point - this shouldn't happen");
-      return false;
-    }
-  }
-
-  unsigned int points_added = 0;
-  for (std::size_t i = 1; i <= num_steps + 1; ++i)
-  {
-    double t = (double)i / (double)(num_steps + 1);
-    std::unique_ptr<JointTrajectoryPoint> new_point;
-    interpolate(prev_traj_point, target_point, t, new_point);
-    if (new_point)
-    {
-      if ((collision_check) && (isInCollision(new_point->jointPoint())))
-      {
-        ROS_WARN_STREAM("Collision detected at " << points_added << " among " << (num_steps + 1) << " points for "
-                                                 << traj_point->name());
-        points_local.clear();
-        throw CollisionDetected("Collision detected while interpolating " + traj_point->name());
-      }
-      else
-      {
-        // Lock the joints
-        auto new_point_joints = new_point->jointPoint();
-        JointLocker::lockJoints(prev_point, new_point_joints, options);
-        auto locked_new_point =
-            std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(new_point_joints, new_point->time(), ""));
-
-        points_local.push_back(toJointTrajPtMsg(*locked_new_point));
-        points_added++;
-        ROS_INFO_STREAM(points_added << " points among " << (num_steps + 1) << " successfully interpolated for "
-                                     << traj_point->name());
-      }
-    }
-    else
-    {
-      ROS_WARN_STREAM("Conversion to joint trajectory failed at " << points_added << " among " << (num_steps + 1)
-                                                                  << "points for " << traj_point->name()
-                                                                  << ". Exiting without interpolation");
-      points_local.clear();
-      return false;
-    }
-  }
-  // Append the global points with local_points
-  points.insert(points.end(), points_local.begin(), points_local.end());
-  ROS_INFO_STREAM("Appending trajectory point, size: " << points.size());
-  points_local.clear();
-  return true;
+  return trajectory_planner_.jointInterpolation(*this, traj_point, points, num_steps, collision_check);
 }
 
 bool Robot::cartesianInterpolation(const std::unique_ptr<TrajectoryPoint>& traj_point,
                                    std::vector<trajectory_msgs::JointTrajectoryPoint>& points, unsigned int num_steps,
                                    bool collision_check)
 {
-  // Create a local vector for storing interpolated points and append
-  // it with last element of global points to be used for interpolation
-  std::vector<trajectory_msgs::JointTrajectoryPoint> points_local;
-  points_local.clear();
-  points_local.push_back(points.back());
-
-  trajectory_msgs::JointTrajectoryPoint prev_point_info = points.back();
-
-  // Convert the previous point stored in points to Cartesian Trajectory Point
-  std::unique_ptr<TrajectoryPoint> prev_point = std::unique_ptr<TrajectoryPoint>(
-      new JointTrajectoryPoint(prev_point_info.positions, prev_point_info.time_from_start.toSec(), ""));
-  std::unique_ptr<CartTrajectoryPoint> prev_traj_point = prev_point->toCartTrajPoint(*this);
-  std::unique_ptr<CartTrajectoryPoint> target_point;
-
-  if (prev_traj_point)
-  {
-    target_point = traj_point->toCartTrajPoint(*this);
-    if (!target_point)
-    {
-      ROS_ERROR_STREAM("Failed to find FK for " << traj_point->name());
-      return false;
-    }
-  }
-  else
-  {
-    ROS_ERROR_STREAM("Failed to find FK for already added point. This is unexpected.");
-    return false;
-  }
-
-  unsigned int points_added = 0;
-  for (std::size_t i = 1; i <= num_steps + 1; ++i)
-  {
-    double t = (double)i / (double)(num_steps + 1);
-    std::unique_ptr<CartTrajectoryPoint> new_point_cart;
-    interpolate(prev_traj_point, target_point, t, new_point_cart);
-
-    std::unique_ptr<TrajectoryPoint> new_point =
-        std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(new_point_cart->pose(), new_point_cart->time(), ""));
-
-    // Add new point at the end of Joint Trajectory (named points_local)
-    if (jointInterpolation(new_point, points_local, (unsigned int)0, collision_check))
-    {
-      points_added++;
-      ROS_INFO_STREAM(points_added << " points among " << (num_steps + 1) << " added successfullyfor "
-                                   << traj_point->name());
-    }
-    else
-    {
-      ROS_WARN_STREAM("Conversion to joint trajectory failed at " << points_added << " among " << (num_steps + 1)
-                                                                  << "points for " << traj_point->name()
-                                                                  << ". Exiting without interpolation");
-      points_local.clear();
-      return false;
-    }
-  }
-
-  // Append the global points with local_points
-  points.insert(points.end(), points_local.begin() + 1, points_local.end());
-  ROS_INFO_STREAM("Appending trajectory point, size: " << points.size());
-  points_local.clear();
-  return true;
+  return trajectory_planner_.cartesianInterpolation(*this, traj_point, points, num_steps, collision_check);
 }
 
 void Robot::interpolate(const std::unique_ptr<JointTrajectoryPoint>& from,
@@ -1307,16 +1064,13 @@ bool Robot::isConfigChange(const std::vector<double> jp1, const std::vector<doub
 {
   // The maximum allowed change in joint value
   const double MAX_JOINT_CHANGE = 90.0 * M_PI / 180.0;
-
   // The number of joints allowed to exeed the maximum joint change.
   const int MAX_JOINT_CHANGE_COUNT = 1;
-
   if (jp1.size() != jp2.size())
   {
     ROS_ERROR_STREAM("Cannot check for config change, size mismatch");
     return true;
   }
-
   size_t j_change_count = 0;
   for (size_t ii = 0; ii < jp1.size(); ii++)
   {
@@ -1333,7 +1087,6 @@ bool Robot::isConfigChange(const std::vector<double> jp1, const std::vector<doub
       return true;
     }
   }
-
   return false;
 }
 

--- a/moveit_simple/src/trajectory_planner.cpp
+++ b/moveit_simple/src/trajectory_planner.cpp
@@ -1,0 +1,322 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <moveit_simple/trajectory_planner.h>
+#include <moveit_simple/conversions.h>
+#include <moveit_simple/robot.h>
+#include <moveit_simple/joint_locker.h>
+
+namespace moveit_simple {
+
+void TrajectoryPlanner::addTrajPoint(const std::string& traj_name, std::unique_ptr<TrajectoryPoint>& point,
+                         const InterpolationType& type, const unsigned int num_steps)
+{
+  std::lock_guard<std::recursive_mutex> guard(trajectory_info_map_mutex_);
+  traj_info_map_[traj_name].push_back({ std::move(point), type, num_steps });
+}
+
+void TrajectoryPlanner::clearTrajectory(const std::string& traj_name)
+{
+  std::lock_guard<std::recursive_mutex> guard(trajectory_info_map_mutex_);
+  traj_info_map_.erase(traj_name);
+}
+
+std::vector<moveit_simple::JointTrajectoryPoint> TrajectoryPlanner::plan(Robot& robot, const std::string traj_name, bool collision_check)
+{
+  std::vector<moveit_simple::JointTrajectoryPoint> plan;
+
+  if (traj_info_map_.count(traj_name))
+  {
+    std::vector<trajectory_msgs::JointTrajectoryPoint> ROS_trajectory_points;
+
+    try
+    {
+      if (toJointTrajectory(robot, traj_name, ROS_trajectory_points, collision_check))
+      {
+        // Modify the speed of execution for the trajectory based off of the speed_modifier
+        for (std::size_t i = 0; i < ROS_trajectory_points.size(); i++)
+        {
+          ROS_trajectory_points[i].time_from_start *= (1.0 / robot.getSpeedModifier());
+        }
+
+        std::vector<moveit_simple::JointTrajectoryPoint> goal = toJointTrajectoryPoint(ROS_trajectory_points);
+
+        ROS_INFO_STREAM("Successfully planned out trajectory: [" << traj_name << "]");
+
+        return goal;
+      }
+      else
+      {
+        ROS_ERROR_STREAM("Failed to convert [" << traj_name << "] to joint trajectory");
+        throw IKFailException("Conversion to joint trajectory failed for " + traj_name);
+      }
+    }
+    catch (CollisionDetected& cd)
+    {
+      ROS_ERROR_STREAM("Collision detected in [" << traj_name << "]");
+      throw cd;
+    }
+  }
+  else
+  {
+    ROS_ERROR_STREAM("Trajectory [" << traj_name << "] not found");
+    throw std::invalid_argument("No trajectory found named " + traj_name);
+  }
+ return plan;
+}
+
+bool TrajectoryPlanner::toJointTrajectory(Robot& robot, const std::string traj_name, std::vector<trajectory_msgs::JointTrajectoryPoint>& points,
+                              bool collision_check)
+{
+  const TrajectoryInfo& traj_info = traj_info_map_[traj_name];
+
+  // The first point in any trajectory is the current pose
+  std::vector<double> current_joint_position = robot.getJointState();
+  points.clear();
+  points.push_back(toJointTrajPtMsg(current_joint_position, 0.0));
+
+  for (size_t i = 0; i < traj_info.size(); ++i)
+  {
+    const std::unique_ptr<TrajectoryPoint>& traj_point = traj_info[i].point;
+    if (traj_info[i].type == interpolation_type::JOINT)
+    {
+      if (jointInterpolation(robot, traj_point, points, traj_info[i].num_steps, collision_check))
+      {
+        ROS_INFO_STREAM("Trajectory successfully added till " << traj_point->name());
+      }
+      else
+      {
+        ROS_ERROR_STREAM("Conversion to joint trajectory failed for " << traj_name << " due to IK failure of "
+                                                                      << traj_point->name());
+        return false;
+      }
+    }
+    else if (traj_info[i].type == interpolation_type::CARTESIAN)
+    {
+      if (robot.cartesianInterpolation(traj_point, points, traj_info[i].num_steps, collision_check))
+      {
+        ROS_INFO_STREAM("Trajectory successfully added till " << traj_point->name());
+      }
+      else
+      {
+        ROS_ERROR_STREAM("Conversion to joint trajectory failed for " << traj_name << " before adding "
+                                                                      << traj_point->name());
+        return false;
+      }
+    }
+    else
+    {
+      ROS_ERROR_STREAM("Unknown interpolation call " << traj_info[i].type);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool TrajectoryPlanner::jointInterpolation(Robot& robot, const std::unique_ptr<TrajectoryPoint>& traj_point,
+                               std::vector<trajectory_msgs::JointTrajectoryPoint>& points, unsigned int num_steps,
+                               bool collision_check)
+{
+  const double IK_TIMEOUT = 0.250;  // 250 ms for IK solving
+
+  auto options = traj_point->getJointLockOptions();
+
+  // Check to make sure the points vector is not empty. At minimum, it should plan from the current state.
+  if (!points.size())
+  {
+    ROS_ERROR_STREAM("jointInterpolation was given an invalid value for `points`. This vector may not be empty");
+    return false;
+  }
+
+  // Get the last point in the points trajectory to connect it to this new trajectory
+  trajectory_msgs::JointTrajectoryPoint prev_point_info = points.back();
+  std::vector<double> prev_point = prev_point_info.positions;
+  double prev_time = prev_point_info.time_from_start.toSec();
+
+  // Convert the previous point stored in points to Joint Trajectory Point
+  std::unique_ptr<JointTrajectoryPoint> prev_traj_point =
+      std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(prev_point, prev_time, ""));
+
+  std::unique_ptr<JointTrajectoryPoint> target_point;
+  if (traj_point->type() != TrajectoryPoint::JOINT)
+  {
+    const size_t MAX_IK_ATTEMPTS = 2;
+    size_t num_attempts = 0;
+
+    while (true)
+    {
+      num_attempts++;
+      target_point = traj_point->toJointTrajPoint(robot, IK_TIMEOUT, prev_point);
+
+      if (target_point)
+      {
+        if (robot.isConfigChange(prev_point, target_point->jointPoint()))
+        {
+          ROS_WARN_STREAM("Configuration change detected in move to/from joint state: ("
+                          << traj_point->name() << "), of type: " << traj_point->type() << " to joint trajectory");
+        }
+        else
+        {
+          ROS_INFO_STREAM("Found proper IK (no config change) in " << num_attempts << " attempts");
+          break;
+        }
+      }
+      else
+      {
+        ROS_WARN_STREAM("Failed to convert trajectory point:  ("
+                        << traj_point->name() << "), of type: " << traj_point->type() << " to joint trajectory");
+        return false;
+      }
+      if (num_attempts >= MAX_IK_ATTEMPTS)
+      {
+        ROS_ERROR_STREAM("Failed to find proper IK (no config change) in " << num_attempts << " attempts");
+        return false;
+      }
+    }
+  }
+  else
+  {
+    target_point = traj_point->toJointTrajPoint(robot, IK_TIMEOUT, prev_point);
+    if (!target_point)
+    {
+      ROS_WARN_STREAM("Failed to convert joint point - this shouldn't happen");
+      return false;
+    }
+  }
+
+  // Create a local vector for storing interpolated points
+  std::vector<trajectory_msgs::JointTrajectoryPoint> points_local;
+  unsigned int points_added = 0;
+  // TODO (mlautman): Explain why we are adding num_steps + 1 instead of just num_steps.
+  for (std::size_t i = 1; i <= num_steps + 1; ++i)
+  {
+    double t = (double)i / (double)(num_steps + 1);
+    std::unique_ptr<JointTrajectoryPoint> new_point;
+    robot.interpolate(prev_traj_point, target_point, t, new_point);
+    if (new_point)
+    {
+      if ((collision_check) && (robot.isInCollision(new_point->jointPoint())))
+      {
+        ROS_WARN_STREAM("Collision detected at " << points_added << " among " << (num_steps + 1) << " points for "
+                                                 << traj_point->name());
+        // TODO (mlautman): preserve points_local for debugging
+        points_local.clear();
+        throw CollisionDetected("Collision detected while interpolating " + traj_point->name());
+      }
+      else
+      {
+        // Lock the joints
+        auto new_point_joints = new_point->jointPoint();
+        JointLocker::lockJoints(prev_point, new_point_joints, options);
+        auto locked_new_point =
+            std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(new_point_joints, new_point->time(), ""));
+
+        points_local.push_back(toJointTrajPtMsg(*locked_new_point));
+        points_added++;
+        ROS_INFO_STREAM(points_added << " points among " << (num_steps + 1) << " successfully interpolated for "
+                                     << traj_point->name());
+      }
+    }
+    else
+    {
+      ROS_WARN_STREAM("Conversion to joint trajectory failed at " << points_added << " among " << (num_steps + 1)
+                                                                  << "points for " << traj_point->name()
+                                                                  << ". Exiting without interpolation");
+      points_local.clear();
+      return false;
+    }
+  }
+  // Append the global points with local_points
+  points.insert(points.end(), points_local.begin(), points_local.end());
+  ROS_INFO_STREAM("Appending trajectory point, size: " << points.size());
+  points_local.clear();
+  return true;
+}
+
+bool TrajectoryPlanner::cartesianInterpolation(Robot& robot,
+                                   const std::unique_ptr<TrajectoryPoint>& traj_point,
+                                   std::vector<trajectory_msgs::JointTrajectoryPoint>& points, unsigned int num_steps,
+                                   bool collision_check)
+{
+  // Create a local vector for storing interpolated points and append
+  // it with last element of global points to be used for interpolation
+  std::vector<trajectory_msgs::JointTrajectoryPoint> points_local;
+  points_local.clear();
+  points_local.push_back(points.back());
+
+  trajectory_msgs::JointTrajectoryPoint prev_point_info = points.back();
+
+  // Convert the previous point stored in points to Cartesian Trajectory Point
+  std::unique_ptr<TrajectoryPoint> prev_point = std::unique_ptr<TrajectoryPoint>(
+      new JointTrajectoryPoint(prev_point_info.positions, prev_point_info.time_from_start.toSec(), ""));
+  std::unique_ptr<CartTrajectoryPoint> prev_traj_point = prev_point->toCartTrajPoint(robot);
+  std::unique_ptr<CartTrajectoryPoint> target_point;
+
+  if (prev_traj_point)
+  {
+    target_point = traj_point->toCartTrajPoint(robot);
+    if (!target_point)
+    {
+      ROS_ERROR_STREAM("Failed to find FK for " << traj_point->name());
+      return false;
+    }
+  }
+  else
+  {
+    ROS_ERROR_STREAM("Failed to find FK for already added point. This is unexpected.");
+    return false;
+  }
+
+  unsigned int points_added = 0;
+  for (std::size_t i = 1; i <= num_steps + 1; ++i)
+  {
+    double t = (double)i / (double)(num_steps + 1);
+    std::unique_ptr<CartTrajectoryPoint> new_point_cart;
+    robot.interpolate(prev_traj_point, target_point, t, new_point_cart);
+
+    std::unique_ptr<TrajectoryPoint> new_point =
+        std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(new_point_cart->pose(), new_point_cart->time(), ""));
+
+    // Add new point at the end of Joint Trajectory (named points_local)
+    if (jointInterpolation(robot, new_point, points_local, (unsigned int)0, collision_check))
+    {
+      points_added++;
+      ROS_INFO_STREAM(points_added << " points among " << (num_steps + 1) << " added successfullyfor "
+                                   << traj_point->name());
+    }
+    else
+    {
+      ROS_WARN_STREAM("Conversion to joint trajectory failed at " << points_added << " among " << (num_steps + 1)
+                                                                  << "points for " << traj_point->name()
+                                                                  << ". Exiting without interpolation");
+      points_local.clear();
+      return false;
+    }
+  }
+
+  // Append the global points with local_points
+  points.insert(points.end(), points_local.begin() + 1, points_local.end());
+  ROS_INFO_STREAM("Appending trajectory point, size: " << points.size());
+  points_local.clear();
+  return true;
+}
+
+
+} // namespace moveit_simple

--- a/moveit_simple/test/kuka_kr210.cpp
+++ b/moveit_simple/test/kuka_kr210.cpp
@@ -37,7 +37,7 @@ class UserRobotTest : public ::testing::Test
 protected:
   std::unique_ptr<moveit_simple::OnlineRobot> robot;
   virtual void SetUp()
-  {      
+  {
   robot = std::unique_ptr<moveit_simple::OnlineRobot> (new moveit_simple::OnlineRobot
                   (ros::NodeHandle(), "robot_description", "manipulator"));
   ros::Duration(2.0).sleep();  //wait for tf tree to populate
@@ -62,7 +62,7 @@ public:
   using moveit_simple::OnlineRobot::cartesianInterpolation;
   using moveit_simple::OnlineRobot::isInCollision;
 };
-  
+
 /**
  * @brief DeveloperRobotTest is a fixture for testing protected methods.
  * Objects that can be directly used inside the test
@@ -74,7 +74,7 @@ class DeveloperRobotTest : public ::testing::Test
 protected:
   std::unique_ptr<DeveloperRobot> robot2;
   virtual void SetUp()
-  {      
+  {
   robot2 = std::unique_ptr<DeveloperRobot> (new DeveloperRobot
                   (ros::NodeHandle(), "robot_description", "manipulator"));
   ros::Duration(2.0).sleep();  //wait for tf tree to populate
@@ -87,7 +87,7 @@ protected:
 
 TEST(MoveitSimpleTest, construction_robot)
 {
-  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");  
+  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
 }
 
 
@@ -100,7 +100,7 @@ TEST(MoveitSimpleTest, construction_online_robot)
 TEST(MoveitSimpleTest, reachability)
 {
   moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity(); 
+  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
   ros::Duration(2.0).sleep();  //wait for tf tree to populate
 
   ROS_INFO_STREAM("Testing reachability of unknown point, should fail");
@@ -122,7 +122,7 @@ TEST(MoveitSimpleTest, reachability)
 TEST_F(UserRobotTest, add_trajectory)
 {
   const std::string TRAJECTORY_NAME("traj1");
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity(); 
+  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
   const moveit_simple::InterpolationType cart = moveit_simple::interpolation_type::CARTESIAN;
   const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
 
@@ -131,13 +131,13 @@ TEST_F(UserRobotTest, add_trajectory)
   EXPECT_THROW(robot->addTrajPoint(TRAJECTORY_NAME, pose, "random_link", 5.0), tf2::TransformException);
   ROS_INFO_STREAM("Testing trajectory adding of points");
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "home",      0.5));
-  
+
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint1", 1.0, joint, 5));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "tf_pub1", 2.0, cart, 8));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint2", 3.0));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint3", 4.0, joint));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, pose, "tool0", 5.0));
-  
+
   EXPECT_NO_THROW(robot->execute(TRAJECTORY_NAME));
 
   EXPECT_NO_THROW(robot->addTrajPoint("traj2", "waypoint4", 4.5));
@@ -176,7 +176,7 @@ TEST_F(DeveloperRobotTest, planning)
 
   EXPECT_TRUE(robot2->getJointSolution(cart_interpolated_expected_pose, 3.0, seed, cart_interpolated_expected_joint));
 
-  // joint_point1,joint_point4, cart_point1 and cart_point3 
+  // joint_point1,joint_point4, cart_point1 and cart_point3
   // represent the same pose
   // joint_point2, cart_point2 and joint_point3 represent the same pose
   std::unique_ptr<moveit_simple::TrajectoryPoint> joint_point1 =
@@ -432,7 +432,7 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "tf_pub1",   2.0));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint2", 3.0));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint3", 4.0));
-  
+
   // Test 1 -- Max_Execution_Speed: Plan & then Execute that Plan separately
   robot->setSpeedModifier(1.0);
   EXPECT_TRUE(robot->getSpeedModifier() == 1.0);
@@ -440,11 +440,11 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   std::vector<moveit_simple::JointTrajectoryPoint> goal;
 
   EXPECT_NO_THROW(goal = robot->plan(TRAJECTORY_NAME));
-  EXPECT_NO_THROW(robot->execute(goal));  
-  
+  EXPECT_NO_THROW(robot->execute(goal));
+
   execution_time_check_1 = goal[goal.size()-1].time();
   EXPECT_TRUE(execution_time_check_1 >= 0.0);
-  ROS_INFO_STREAM("Time for single traj. execution at MAX speed: " 
+  ROS_INFO_STREAM("Time for single traj. execution at MAX speed: "
     << execution_time_check_1 << " seconds");
 
   // Test 2 -- Half_Execution_Speed: Plan & Execute
@@ -482,12 +482,12 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   delta_time_for_speed_limits = delta_max_half_speeds - delta_half_min_speeds;
   EXPECT_NEAR(delta_time_for_speed_limits, 0.0, execution_time_tolerance);
 
-  if(abs(delta_time_for_speed_limits) > execution_time_tolerance) 
+  if(abs(delta_time_for_speed_limits) > execution_time_tolerance)
   {
-    ROS_ERROR_STREAM("Time diff between [MAX_SPEED/REGULAR_SPEED] --> [" << 
-                     execution_time_check_1 << ", " << execution_time_check_2 << 
+    ROS_ERROR_STREAM("Time diff between [MAX_SPEED/REGULAR_SPEED] --> [" <<
+                     execution_time_check_1 << ", " << execution_time_check_2 <<
                      "] & [REGULAR_SPEED/MIN_SPEED] --> [" << execution_time_check_2 <<
-                     ", " << execution_time_check_3 << "] is " << delta_time_for_speed_limits << 
+                     ", " << execution_time_check_3 << "] is " << delta_time_for_speed_limits <<
                      "; but tolerance limit is [" << execution_time_tolerance << "]");
   }
 }
@@ -623,7 +623,7 @@ TEST_F(UserRobotTest, custom_tool_link)
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint3", "tool_custom", 4.0));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint1", tool_name, 5.0, joint, 5));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, pose_eigen, "tool0", 6.0));
-  
+
   EXPECT_NO_THROW(robot->execute(TRAJECTORY_NAME));
 }
 

--- a/moveit_simple/test/kuka_kr210.cpp
+++ b/moveit_simple/test/kuka_kr210.cpp
@@ -100,7 +100,7 @@ TEST(MoveitSimpleTest, construction_online_robot)
 TEST(MoveitSimpleTest, reachability)
 {
   moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+  const Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
   ros::Duration(2.0).sleep();  //wait for tf tree to populate
 
   ROS_INFO_STREAM("Testing reachability of unknown point, should fail");
@@ -122,7 +122,7 @@ TEST(MoveitSimpleTest, reachability)
 TEST_F(UserRobotTest, add_trajectory)
 {
   const std::string TRAJECTORY_NAME("traj1");
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+  const Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
   const moveit_simple::InterpolationType cart = moveit_simple::interpolation_type::CARTESIAN;
   const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
 
@@ -161,9 +161,9 @@ TEST_F(DeveloperRobotTest, planning)
   std::vector<double>seed;
   std::vector<double>cart_interpolated_expected_joint;
 
-  Eigen::Affine3d pose1;
-  Eigen::Affine3d pose2;
-  Eigen::Affine3d joint_interpolated_expected_pose;
+  Eigen::Isometry3d pose1;
+  Eigen::Isometry3d pose2;
+  Eigen::Isometry3d joint_interpolated_expected_pose;
 
   EXPECT_TRUE(robot2->getPose(joint1, pose1));
   EXPECT_TRUE(robot2->getPose(joint2, pose2));
@@ -171,7 +171,7 @@ TEST_F(DeveloperRobotTest, planning)
 
   Eigen::Quaterniond point1_quaternion(pose1.rotation());
   Eigen::Quaterniond point2_quaternion(pose2.rotation());
-  Eigen::Affine3d cart_interpolated_expected_pose(point1_quaternion.slerp(0.5, point2_quaternion));
+  Eigen::Isometry3d cart_interpolated_expected_pose(point1_quaternion.slerp(0.5, point2_quaternion));
   cart_interpolated_expected_pose.translation() =  0.5*(pose2.translation() + pose1.translation());
 
   EXPECT_TRUE(robot2->getJointSolution(cart_interpolated_expected_pose, 3.0, seed, cart_interpolated_expected_joint));
@@ -232,7 +232,7 @@ TEST_F(DeveloperRobotTest, planning)
 
   ROS_INFO_STREAM("Converting the joint positions to poses to compare " <<
                                                 "against expected poses");
-  std::vector<Eigen::Affine3d> pose_out;
+  std::vector<Eigen::Isometry3d> pose_out;
   pose_out.resize(points.size());
   for (std::size_t i = 0; i < points.size(); ++i)
   {
@@ -338,16 +338,16 @@ TEST_F(DeveloperRobotTest, interpolation)
   ROS_INFO_STREAM("joint_expected" << joint_out);
 
   // Cartesian Interpolation Test
-  Eigen::Affine3d pose1 = Eigen::Affine3d::Identity();
+  Eigen::Isometry3d pose1 = Eigen::Isometry3d::Identity();
   pose1.translation() = Eigen::Vector3d(1.9,0.0,2.2);
   Eigen::Quaterniond rot1;
   rot1.setFromTwoVectors(Eigen::Vector3d(0,-0.5,0), Eigen::Vector3d(1.9,0.0,2.2));
   pose1.linear() = rot1.toRotationMatrix();
 
-  Eigen::Affine3d pose2 = Eigen::Affine3d::Identity();
+  Eigen::Isometry3d pose2 = Eigen::Isometry3d::Identity();
   pose2.translation() = Eigen::Vector3d(1.9,0.0,2.7);
 
-  Eigen::Affine3d pose3 = Eigen::Affine3d::Identity();
+  Eigen::Isometry3d pose3 = Eigen::Isometry3d::Identity();
   pose3.translation() = Eigen::Vector3d(-0.592,-0.000,3.452);
   Eigen::Quaterniond rot3;
   rot3.setFromTwoVectors(Eigen::Vector3d(3.142,-0.964,3.142), Eigen::Vector3d(-0.592,-0.000,3.452));
@@ -355,7 +355,7 @@ TEST_F(DeveloperRobotTest, interpolation)
 
   Eigen::Quaterniond point1_quaternion(pose1.rotation());
   Eigen::Quaterniond point2_quaternion(pose2.rotation());
-  Eigen::Affine3d pose_expected(point1_quaternion.slerp(0.5, point2_quaternion));
+  Eigen::Isometry3d pose_expected(point1_quaternion.slerp(0.5, point2_quaternion));
   pose_expected.translation() = Eigen::Vector3d(1.9,0.0,2.45);
 
   const std::unique_ptr<moveit_simple::CartTrajectoryPoint> cart_point1 =
@@ -495,10 +495,10 @@ TEST_F(UserRobotTest, speed_reconfiguration)
 
 TEST_F(UserRobotTest, kinematics)
 {
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
-  Eigen::Affine3d pose1;
-  Eigen::Affine3d pose2;
-  Eigen::Affine3d pose3;
+  const Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d pose1;
+  Eigen::Isometry3d pose2;
+  Eigen::Isometry3d pose3;
   std::vector<double> joint_point1(6,M_PI/6);
   std::vector<double> joint_point2;
   std::vector<double> joint_point3;
@@ -547,10 +547,10 @@ TEST_F(UserRobotTest, custom_tool_link)
   const moveit_simple::InterpolationType cart = moveit_simple::interpolation_type::CARTESIAN;
   const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
 
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
-  Eigen::Affine3d pose1;
-  Eigen::Affine3d pose2;
-  Eigen::Affine3d pose3;
+  const Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d pose1;
+  Eigen::Isometry3d pose2;
+  Eigen::Isometry3d pose3;
   std::vector<double> joint_point1(6,M_PI/6);
   std::vector<double> joint_point2;
   std::vector<double> joint_point3;
@@ -594,7 +594,7 @@ TEST_F(UserRobotTest, custom_tool_link)
   EXPECT_TRUE(pose1.isApprox(pose3,1e-3));
 
   // Testing addTrajPoint() with custom_tool_frame as eef
-  Eigen::Affine3d pose_msg_to_eigen;
+  Eigen::Isometry3d pose_msg_to_eigen;
   geometry_msgs::Pose pose_buffer;
 
   // We take the Origin of our reference frame in consideration as the "known pose"
@@ -610,7 +610,7 @@ TEST_F(UserRobotTest, custom_tool_link)
 
   tf::poseMsgToEigen(pose_buffer, pose_msg_to_eigen);
 
-  const Eigen::Affine3d pose_eigen = pose_msg_to_eigen;
+  const Eigen::Isometry3d pose_eigen = pose_msg_to_eigen;
 
   const std::string TRAJECTORY_NAME("traj1");
 

--- a/moveit_simple/test/launch/kuka_kr210.launch
+++ b/moveit_simple/test/launch/kuka_kr210.launch
@@ -20,7 +20,7 @@
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find moveit_simple)/test/resources/kuka_kr210/kuka_kr210.srdf" />
-  
+
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">
     <rosparam command="load" file="$(find moveit_simple)/test/resources/kuka_kr210/joint_limits.yaml"/>

--- a/moveit_simple/test/launch/kuka_kr210.launch
+++ b/moveit_simple/test/launch/kuka_kr210.launch
@@ -46,4 +46,8 @@
   <!-- Static tranform publisher for testing tf lookup -->
   <node name="tf_pub1" type="static_transform_publisher" pkg="tf" args="1.9 0 2.2 0 -0.5 0 base_link tf_pub1 100"/>
 
+
+  <!-- Static tranform publisher between base_link and world -->
+  <node name="tf_pub2" type="static_transform_publisher" pkg="tf" args="0 0 0 0 0 0 base_link world 100"/>
+
 </launch>

--- a/moveit_simple/test/launch/motoman_mh5.launch
+++ b/moveit_simple/test/launch/motoman_mh5.launch
@@ -17,7 +17,7 @@
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find moveit_simple)/test/resources/motoman_mh5/config/motoman_mh5_robot.srdf" />
-  
+
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">
     <rosparam command="load" file="$(find moveit_simple)/test/resources/motoman_mh5/config/joint_limits.yaml"/>

--- a/moveit_simple/test/launch/tool_windup_utest.launch
+++ b/moveit_simple/test/launch/tool_windup_utest.launch
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- Unit test launch file -->
+  <!-- The name of the parameter under which the URDF is loaded -->
+  <arg name="robot_description" default="robot_description"/>
+
+  <!-- Launch test node -->
+  <arg name="run_test_node" default="true"/>
+
+  <!-- Debug Info -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <include file="$(find moveit_simple)/test/launch/kuka_kr210.launch">
+    <arg name="robot_description" value="$(arg robot_description)"/>
+    <arg name="urdf_file" value="$(find moveit_simple)/test/resources/kuka_kr210/kr210l150.urdf"/>
+    <arg name="urdf_file_custom_tool" value="$(find moveit_simple)/test/resources/kuka_kr210/kuka_custom_tool.urdf"/>
+    <arg name="run_test_node" value="$(arg run_test_node)"/>
+  </include>
+
+  <!-- Test Node -->
+  <test test-name="tool_windup_utest" pkg="moveit_simple" type="tool_windup_utest"
+  launch-prefix="$(arg launch_prefix)" if="$(arg run_test_node)" time-limit="500.0"/>
+</launch>

--- a/moveit_simple/test/motoman_mh5.cpp
+++ b/moveit_simple/test/motoman_mh5.cpp
@@ -35,12 +35,12 @@ class UserRobotTest : public ::testing::Test
 {
 protected:
   std::unique_ptr<moveit_simple::OnlineRobot> user_robot;
-  
+
   virtual void SetUp()
-  {      
+  {
     user_robot = std::unique_ptr<moveit_simple::OnlineRobot> (new moveit_simple::OnlineRobot
       (ros::NodeHandle(), "robot_description", "manipulator", "base_link", "link_t"));
-    
+
     ros::Duration(2.0).sleep();  //wait for tf tree to populate
   }
 
@@ -62,9 +62,9 @@ public:
   using moveit_simple::OnlineRobot::cartesianInterpolation;
   using moveit_simple::OnlineRobot::isInCollision;
   using moveit_simple::OnlineRobot::getFK;
-  using moveit_simple::OnlineRobot::getIK;  
+  using moveit_simple::OnlineRobot::getIK;
 };
-  
+
 /**
  * @brief DeveloperRobotTest is a fixture for testing protected methods.
  * Objects that can be directly used inside the test
@@ -75,7 +75,7 @@ class DeveloperRobotTest : public ::testing::Test
 protected:
   std::unique_ptr<DeveloperRobot> developer_robot;
   virtual void SetUp()
-  {      
+  {
     developer_robot = std::unique_ptr<DeveloperRobot> (new DeveloperRobot
       (ros::NodeHandle(), "robot_description", "manipulator", "base_link", "link_t"));
 
@@ -95,7 +95,7 @@ struct KinematicsTestData
 
   // Forward kinematics from base -> tool_custom
   std::vector<double> translation_tool_custom; // [x, y, z]
-  std::vector<double> rotation_tool_custom; // Quaternion [x, y, z, w]  
+  std::vector<double> rotation_tool_custom; // Quaternion [x, y, z, w]
 };
 
 TEST_F(DeveloperRobotTest, kinematics)
@@ -155,7 +155,7 @@ TEST_F(DeveloperRobotTest, kinematics)
     EXPECT_NEAR(tool_custom_translation.x(), pose.translation_tool_custom[0], ABS_ERROR);
     EXPECT_NEAR(tool_custom_translation.y(), pose.translation_tool_custom[1], ABS_ERROR);
     EXPECT_NEAR(tool_custom_translation.z(), pose.translation_tool_custom[2], ABS_ERROR);
-    
+
     Eigen::Quaterniond tool_custom_rotation = Eigen::Quaterniond(tool_custom_calculated_pose.linear());
     EXPECT_NEAR(tool_custom_rotation.x(), pose.rotation_tool_custom[0], ABS_ERROR);
     EXPECT_NEAR(tool_custom_rotation.y(), pose.rotation_tool_custom[1], ABS_ERROR);
@@ -174,12 +174,12 @@ TEST_F(DeveloperRobotTest, kinematics)
     EXPECT_NEAR(check_joint_translation.x(), pose.translation_tool_custom[0], ABS_ERROR);
     EXPECT_NEAR(check_joint_translation.y(), pose.translation_tool_custom[1], ABS_ERROR);
     EXPECT_NEAR(check_joint_translation.z(), pose.translation_tool_custom[2], ABS_ERROR);
-    
+
     Eigen::Quaterniond check_joint_rotation = Eigen::Quaterniond(check_joint_solution.linear());
     EXPECT_NEAR(check_joint_rotation.x(), pose.rotation_tool_custom[0], ABS_ERROR);
     EXPECT_NEAR(check_joint_rotation.y(), pose.rotation_tool_custom[1], ABS_ERROR);
     EXPECT_NEAR(check_joint_rotation.z(), pose.rotation_tool_custom[2], ABS_ERROR);
-    EXPECT_NEAR(check_joint_rotation.w(), pose.rotation_tool_custom[3], ABS_ERROR);    
+    EXPECT_NEAR(check_joint_rotation.w(), pose.rotation_tool_custom[3], ABS_ERROR);
   };
 
   testKinematics(pose_home);
@@ -192,7 +192,7 @@ TEST_F(DeveloperRobotTest, kinematics)
 
 TEST(MoveitSimpleTest, construction_robot)
 {
-  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");  
+  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
 }
 
 TEST(MoveitSimpleTest, construction_online_robot)
@@ -202,19 +202,19 @@ TEST(MoveitSimpleTest, construction_online_robot)
 
 TEST(MoveitSimpleTest, construction_robot_ikfast)
 {
-  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator", 
-    "base_link", "link_t"); 
+  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator",
+    "base_link", "link_t");
 }
 
 TEST(MoveitSimpleTest, construction_online_robot_ikfast)
 {
-  moveit_simple::OnlineRobot online_robot(ros::NodeHandle(), "robot_description", "manipulator", 
+  moveit_simple::OnlineRobot online_robot(ros::NodeHandle(), "robot_description", "manipulator",
     "base_link", "link_t");
 }
 
 TEST_F(UserRobotTest, reachability)
 {
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity(); 
+  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
 
   ROS_INFO_STREAM("Testing reachability of unknown point, should fail");
   EXPECT_FALSE(user_robot->isReachable("unknown_name"));
@@ -233,14 +233,14 @@ TEST_F(UserRobotTest, reachability)
 TEST_F(UserRobotTest, add_trajectory)
 {
   const std::string TRAJECTORY_NAME("traj1");
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity(); 
+  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
   const moveit_simple::InterpolationType cart = moveit_simple::interpolation_type::CARTESIAN;
   const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
 
   ROS_INFO_STREAM("Testing loading of unknown point, should fail");
   EXPECT_THROW(user_robot->addTrajPoint("bad_traj", "unknown_name", 1.0), std::invalid_argument);
   EXPECT_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, pose, "random_link", 5.0), tf2::TransformException);
-  
+
   ROS_INFO_STREAM("Testing trajectory adding of points");
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "home", 0.5));
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp1", 1.0, joint, 5));
@@ -335,7 +335,7 @@ TEST_F(DeveloperRobotTest, planning)
   EXPECT_EQ(points.size(),14);
 
   ROS_INFO_STREAM("Converting the joint positions to poses to compare against expected poses");
-  
+
   std::vector<Eigen::Affine3d> pose_out;
   pose_out.resize(points.size());
   for (std::size_t i = 0; i < points.size(); ++i)
@@ -537,7 +537,7 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "tf_pub1",   2.0));
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp2", 3.0));
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp3", 4.0));
-  
+
   // Test 1 -- Max_Execution_Speed: Plan & then Execute that Plan separately
   user_robot->setSpeedModifier(1.0);
   EXPECT_TRUE(user_robot->getSpeedModifier() == 1.0);
@@ -545,11 +545,11 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   std::vector<moveit_simple::JointTrajectoryPoint> goal;
 
   EXPECT_NO_THROW(goal = user_robot->plan(TRAJECTORY_NAME));
-  EXPECT_NO_THROW(user_robot->execute(goal));  
-  
+  EXPECT_NO_THROW(user_robot->execute(goal));
+
   execution_time_check_1 = goal[goal.size()-1].time();
   EXPECT_TRUE(execution_time_check_1 >= 0.0);
-  ROS_INFO_STREAM("Time for single traj. execution at MAX speed: " 
+  ROS_INFO_STREAM("Time for single traj. execution at MAX speed: "
     << execution_time_check_1 << " seconds");
 
   // Test 2 -- Half_Execution_Speed: Plan & Execute
@@ -587,12 +587,12 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   delta_time_for_speed_limits = delta_max_half_speeds - delta_half_min_speeds;
   EXPECT_NEAR(delta_time_for_speed_limits, 0.0, execution_time_tolerance);
 
-  if(abs(delta_time_for_speed_limits) > execution_time_tolerance) 
+  if(abs(delta_time_for_speed_limits) > execution_time_tolerance)
   {
-    ROS_ERROR_STREAM("Time diff between [MAX_SPEED/REGULAR_SPEED] --> [" << 
-                     execution_time_check_1 << ", " << execution_time_check_2 << 
+    ROS_ERROR_STREAM("Time diff between [MAX_SPEED/REGULAR_SPEED] --> [" <<
+                     execution_time_check_1 << ", " << execution_time_check_2 <<
                      "] & [REGULAR_SPEED/MIN_SPEED] --> [" << execution_time_check_2 <<
-                     ", " << execution_time_check_3 << "] is " << delta_time_for_speed_limits << 
+                     ", " << execution_time_check_3 << "] is " << delta_time_for_speed_limits <<
                      "; but tolerance limit is [" << execution_time_tolerance << "]");
   }
 }
@@ -726,7 +726,7 @@ TEST_F(UserRobotTest, custom_tool_link)
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp3", "tool_custom", 4.0));
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp1", tool_name, 5.0, joint, 5));
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, pose_eigen, "tool0", 6.0));
-  
+
   EXPECT_NO_THROW(user_robot->execute(TRAJECTORY_NAME));
 }
 

--- a/moveit_simple/test/motoman_mh5.cpp
+++ b/moveit_simple/test/motoman_mh5.cpp
@@ -148,7 +148,7 @@ TEST_F(DeveloperRobotTest, kinematics)
     const std::vector<double> JOINT_SEED(pose.joints.size(), 0.0);
 
     // Testing forward kinematics to tool_custom
-    Eigen::Affine3d tool_custom_calculated_pose;
+    Eigen::Isometry3d tool_custom_calculated_pose;
     ASSERT_TRUE(developer_robot->getFK(pose.joints, tool_custom_calculated_pose));
 
     Eigen::Vector3d tool_custom_translation = tool_custom_calculated_pose.translation();
@@ -164,10 +164,11 @@ TEST_F(DeveloperRobotTest, kinematics)
 
     // Testing inverse kinematics
     std::vector<double> joint_solution;
-    ASSERT_TRUE(developer_robot->getIK(tool_custom_calculated_pose, JOINT_SEED, joint_solution, 10, 15));
+    double timeout = 15;
+    ASSERT_TRUE(developer_robot->getIK(tool_custom_calculated_pose, JOINT_SEED, joint_solution, timeout));
 
     // Checking IK solution with forward kinematics
-    Eigen::Affine3d check_joint_solution;
+    Eigen::Isometry3d check_joint_solution;
     ASSERT_TRUE(developer_robot->getFK(joint_solution, check_joint_solution));
 
     Eigen::Vector3d check_joint_translation = check_joint_solution.translation();
@@ -214,7 +215,7 @@ TEST(MoveitSimpleTest, construction_online_robot_ikfast)
 
 TEST_F(UserRobotTest, reachability)
 {
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+  const Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
 
   ROS_INFO_STREAM("Testing reachability of unknown point, should fail");
   EXPECT_FALSE(user_robot->isReachable("unknown_name"));
@@ -233,7 +234,7 @@ TEST_F(UserRobotTest, reachability)
 TEST_F(UserRobotTest, add_trajectory)
 {
   const std::string TRAJECTORY_NAME("traj1");
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+  const Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
   const moveit_simple::InterpolationType cart = moveit_simple::interpolation_type::CARTESIAN;
   const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
 
@@ -270,9 +271,9 @@ TEST_F(DeveloperRobotTest, planning)
   std::vector<double> seed;
   std::vector<double> cart_interpolated_expected_joint;
 
-  Eigen::Affine3d pose1;
-  Eigen::Affine3d pose2;
-  Eigen::Affine3d joint_interpolated_expected_pose;
+  Eigen::Isometry3d pose1;
+  Eigen::Isometry3d pose2;
+  Eigen::Isometry3d joint_interpolated_expected_pose;
 
   EXPECT_TRUE(developer_robot->getPose(joint1, pose1));
   EXPECT_TRUE(developer_robot->getPose(joint2, pose2));
@@ -280,7 +281,7 @@ TEST_F(DeveloperRobotTest, planning)
 
   Eigen::Quaterniond point1_quaternion(pose1.rotation());
   Eigen::Quaterniond point2_quaternion(pose2.rotation());
-  Eigen::Affine3d cart_interpolated_expected_pose(point1_quaternion.slerp(0.5, point2_quaternion));
+  Eigen::Isometry3d cart_interpolated_expected_pose(point1_quaternion.slerp(0.5, point2_quaternion));
   cart_interpolated_expected_pose.translation() =  0.5*(pose2.translation() + pose1.translation());
 
   EXPECT_TRUE(developer_robot->getJointSolution(cart_interpolated_expected_pose, 3.0, seed, cart_interpolated_expected_joint));
@@ -336,7 +337,7 @@ TEST_F(DeveloperRobotTest, planning)
 
   ROS_INFO_STREAM("Converting the joint positions to poses to compare against expected poses");
 
-  std::vector<Eigen::Affine3d> pose_out;
+  std::vector<Eigen::Isometry3d> pose_out;
   pose_out.resize(points.size());
   for (std::size_t i = 0; i < points.size(); ++i)
   {
@@ -441,24 +442,24 @@ TEST_F(DeveloperRobotTest, interpolation)
   ROS_INFO_STREAM("joint_expected" << joint_out);
 
   // Cartesian Interpolation Test
-  Eigen::Affine3d pose1 = Eigen::Affine3d::Identity();
+  Eigen::Isometry3d pose1 = Eigen::Isometry3d::Identity();
   pose1.translation() = Eigen::Vector3d(0.8, 0.1, 0.3);
   Eigen::Quaterniond rot1(0.66, 0.0, 0.7513, 0.0);
   pose1.linear() = rot1.toRotationMatrix();
 
-  Eigen::Affine3d pose2 = Eigen::Affine3d::Identity();
+  Eigen::Isometry3d pose2 = Eigen::Isometry3d::Identity();
   pose2.translation() = Eigen::Vector3d(0.8, 0.1, 0.5);
   Eigen::Quaterniond rot2(0.4085, 0, 0.9127, 0);
   pose2.linear() = rot2.toRotationMatrix();
 
-  Eigen::Affine3d pose3 = Eigen::Affine3d::Identity();
+  Eigen::Isometry3d pose3 = Eigen::Isometry3d::Identity();
   pose3.translation() = Eigen::Vector3d(-0.3, -0.5, 0.2);
   Eigen::Quaterniond rot3(0.8253, 0.0, 0.5646, 0.0);
   pose3.linear() = rot3.toRotationMatrix();
 
   Eigen::Quaterniond point1_quaternion(pose1.rotation());
   Eigen::Quaterniond point2_quaternion(pose2.rotation());
-  Eigen::Affine3d pose_expected(point1_quaternion.slerp(0.5, point2_quaternion));
+  Eigen::Isometry3d pose_expected(point1_quaternion.slerp(0.5, point2_quaternion));
   pose_expected.translation() = Eigen::Vector3d(0.8, 0.1, 0.4);
 
   const std::unique_ptr<moveit_simple::CartTrajectoryPoint> cart_point1 =
@@ -599,10 +600,10 @@ TEST_F(UserRobotTest, speed_reconfiguration)
 
 TEST_F(UserRobotTest, kinematics)
 {
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
-  Eigen::Affine3d pose1;
-  Eigen::Affine3d pose2;
-  Eigen::Affine3d pose3;
+  const Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d pose1;
+  Eigen::Isometry3d pose2;
+  Eigen::Isometry3d pose3;
   std::vector<double> joint_point1(6,M_PI/6);
   std::vector<double> joint_point2;
   std::vector<double> joint_point3;
@@ -651,10 +652,10 @@ TEST_F(UserRobotTest, custom_tool_link)
   const moveit_simple::InterpolationType cart = moveit_simple::interpolation_type::CARTESIAN;
   const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
 
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
-  Eigen::Affine3d pose1;
-  Eigen::Affine3d pose2;
-  Eigen::Affine3d pose3;
+  const Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d pose1;
+  Eigen::Isometry3d pose2;
+  Eigen::Isometry3d pose3;
   std::vector<double> joint_point1(6,M_PI/6);
   std::vector<double> joint_point2;
   std::vector<double> joint_point3;
@@ -698,7 +699,7 @@ TEST_F(UserRobotTest, custom_tool_link)
   EXPECT_TRUE(pose1.isApprox(pose3,1e-3));
 
   // Testing addTrajPoint() with custom_tool_frame as eef
-  Eigen::Affine3d pose_msg_to_eigen;
+  Eigen::Isometry3d pose_msg_to_eigen;
   geometry_msgs::Pose pose_buffer;
 
   // We take the Origin of our reference frame in consideration as the "known pose"
@@ -714,7 +715,7 @@ TEST_F(UserRobotTest, custom_tool_link)
 
   tf::poseMsgToEigen(pose_buffer, pose_msg_to_eigen);
 
-  const Eigen::Affine3d pose_eigen = pose_msg_to_eigen;
+  const Eigen::Isometry3d pose_eigen = pose_msg_to_eigen;
 
   const std::string TRAJECTORY_NAME("traj1");
 

--- a/moveit_simple/test/resources/kuka_kr210/kuka_custom_tool.urdf
+++ b/moveit_simple/test/resources/kuka_kr210/kuka_custom_tool.urdf
@@ -4,7 +4,7 @@
   <link name="tool0"/>
 
   <link name="tool_custom"/>
-  
+
   <joint name="tool0-tool_custom" type="fixed">
     <parent link="tool0"/>
     <child link="tool_custom"/>

--- a/moveit_simple/test/resources/motoman_mh5/config/ompl_planning.yaml
+++ b/moveit_simple/test/resources/motoman_mh5/config/ompl_planning.yaml
@@ -20,7 +20,7 @@ planner_configs:
   KPIECEkConfigDefault:
     type: geometric::KPIECE
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
     border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
     failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
     min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
@@ -44,7 +44,7 @@ planner_configs:
     temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
     min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
     init_temperature: 10e-6  # initial temperature. default: 10e-6
-    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
     frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
     k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRMkConfigDefault:
@@ -75,9 +75,9 @@ planner_configs:
   STRIDEkConfigDefault:
     type: geometric::STRIDE
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
     use_projected_distance: 0  # whether nearest neighbors are computed based on distances in a projection of the state rather distances in the state space itself. default: 0
-    degree: 16  # desired degree of a node in the Geometric Near-neightbor Access Tree (GNAT). default: 16 
+    degree: 16  # desired degree of a node in the Geometric Near-neightbor Access Tree (GNAT). default: 16
     max_degree: 18  # max degree of a node in the GNAT. default: 12
     min_degree: 12  # min degree of a node in the GNAT. default: 12
     max_pts_per_leaf: 6  # max points per leaf in the GNAT. default: 6
@@ -88,13 +88,13 @@ planner_configs:
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
     temp_change_factor: 0.1  # how much to increase or decrease temp. default: 0.1
     init_temperature: 100  # initial temperature. default: 100
-    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
     frountier_node_ratio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
     cost_threshold: 1e300  # the cost threshold. Any motion cost that is not better will not be expanded. default: inf
   LBTRRTkConfigDefault:
     type: geometric::LBTRRT
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
     epsilon: 0.4  # optimality approximation factor. default: 0.4
   BiESTkConfigDefault:
     type: geometric::BiEST
@@ -102,7 +102,7 @@ planner_configs:
   ProjESTkConfigDefault:
     type: geometric::ProjEST
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LazyPRMkConfigDefault:
     type: geometric::LazyPRM
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()

--- a/moveit_simple/test/resources/motoman_mh5/urdf/motoman_mh5_robot_macro.xacro
+++ b/moveit_simple/test/resources/motoman_mh5/urdf/motoman_mh5_robot_macro.xacro
@@ -50,7 +50,7 @@
       <parent link="${prefix}ee_link"/>
       <child link="${prefix}tool_custom"/>
       <origin rpy="0 0 0" xyz="0 0 0.15"/>
-    </joint>    
+    </joint>
     <!-- End Joints -->
 
     <!-- Waypoints for testing -->

--- a/moveit_simple/test/tool_windup.cpp
+++ b/moveit_simple/test/tool_windup.cpp
@@ -1,0 +1,149 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <eigen_conversions/eigen_msg.h>
+#include <gtest/gtest.h>
+#include <moveit_simple/moveit_simple.h>
+#include <moveit_simple/prettyprint.hpp>
+#include <random_numbers/random_numbers.h>
+
+using testing::Types;
+
+namespace moveit_simple_test
+{
+
+/**
+ * @brief UserRobotTest is a fixture for testing public methods.
+ * Objects that can be directly used inside the test
+ - robot pointer for moveit_simple::OnlineRobot
+*/
+class UserRobotTest : public ::testing::Test
+{
+protected:
+  std::unique_ptr<moveit_simple::OnlineRobot> robot;
+  virtual void SetUp()
+  {
+  robot = std::unique_ptr<moveit_simple::OnlineRobot> (new moveit_simple::OnlineRobot
+                  (ros::NodeHandle(), "robot_description", "manipulator"));
+  ros::Duration(2.0).sleep();  //wait for tf tree to populate
+  }
+  virtual void TearDown()
+  {}
+};
+
+/**
+ * @brief DeveloperRobot is a class inheriting from moveit_simple::OnlineRobot to test protected methods
+ * Add the protected methods(that are required to be tested) in the following list
+*/
+class DeveloperRobot: public moveit_simple::OnlineRobot
+{
+public:
+  using moveit_simple::OnlineRobot::OnlineRobot;
+  using moveit_simple::OnlineRobot::addTrajPoint;
+  using moveit_simple::OnlineRobot::toJointTrajectory;
+  using moveit_simple::OnlineRobot::interpolate;
+  using moveit_simple::OnlineRobot::jointInterpolation;
+  using moveit_simple::OnlineRobot::cartesianInterpolation;
+  using moveit_simple::OnlineRobot::isInCollision;
+};
+
+/**
+ * @brief DeveloperRobotTest is a fixture for testing protected methods.
+ * Objects that can be directly used inside the test
+ - robot pointer for DeveloperRobot
+*/
+
+class DeveloperRobotTest : public ::testing::Test
+{
+protected:
+  std::unique_ptr<DeveloperRobot> robot2;
+  virtual void SetUp()
+  {
+  robot2 = std::unique_ptr<DeveloperRobot> (new DeveloperRobot
+                  (ros::NodeHandle(), "robot_description", "manipulator"));
+  ros::Duration(2.0).sleep();  //wait for tf tree to populate
+  }
+  virtual void TearDown()
+  {}
+};
+
+TEST(MoveitSimpleTest, construction_robot)
+{
+  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
+}
+
+TEST(MoveitSimpleTest, test_limit_ik_windup)
+{
+  ROS_INFO_STREAM("Testing IK solution of waypoint");
+  // initialize robot
+  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
+
+  // run stepwise rotations and provoke windup
+  Eigen::Isometry3d pose(Eigen::Translation3d(Eigen::Vector3d(1.904, 0.000, 2.762)));
+  std::vector<double> joints(6,0);
+  double angle_step = 0.05;
+  size_t steps = 1.5 * M_PI / angle_step + 1;
+  for (size_t i = 0; i < steps; ++i)
+  {
+    pose.rotate(Eigen::AngleAxisd(angle_step, Eigen::Vector3d::UnitX()));
+    robot.getJointSolution(pose, "tool0", 0.01, joints, joints);
+  }
+  EXPECT_TRUE(std::abs(joints.back()) > 1.5 * M_PI);
+
+  // test getter and setter functions for ik_seed_state_fractions_
+  std::map<size_t, double> seed_fractions;
+  seed_fractions[6] = 0.1;  // invalid joint position
+  EXPECT_FALSE(robot.setIKSeedStateFractions(seed_fractions));
+  seed_fractions.clear();
+  seed_fractions[5] = 1.1;  // invalid fraction value
+  EXPECT_FALSE(robot.setIKSeedStateFractions(seed_fractions));
+  seed_fractions.clear();
+  // set ik seed state fractions to 'pull' wrist joint towards 0
+  seed_fractions[5] = 0.3;
+  EXPECT_TRUE(robot.setIKSeedStateFractions(seed_fractions));
+  EXPECT_TRUE(seed_fractions == robot.getIKSeedStateFractions());
+  // enable joint windup limitation
+  robot.limitJointWindup(true);
+
+  // run same rotations as before and verify that windup is disabled
+  pose.linear().setIdentity();
+  for (size_t i = 0; i < steps; ++i)
+  {
+    pose.rotate(Eigen::AngleAxisd(angle_step, Eigen::Vector3d::UnitX()));
+    robot.getJointSolution(pose, "tool0", 0.01, joints, joints);
+  }
+  EXPECT_FALSE(std::abs(joints.back()) > 1.5 * M_PI);
+
+  // stress test with 1000 consecutive random orientations while using the previous solution seed state
+  // this shouldn't produce any windup in the wrist joint at all (abs(value) < pi)
+  random_numbers::RandomNumberGenerator rand(7 /* seed */);
+  steps = 1000;
+  size_t failed_ik_count = 0;
+  size_t failed_windup_count = 0;
+  for (size_t i = 0; i < steps; ++i)
+  {
+    pose.rotate(Eigen::AngleAxisd(rand.uniformReal(-M_PI, M_PI), Eigen::Vector3d::UnitX()));
+    if (!robot.getJointSolution(pose, "tool0", 0.05, joints, joints))
+      ++failed_ik_count;
+    else if (std::abs(joints.back() > 1.5 * M_PI))
+      ++failed_windup_count;
+  }
+  EXPECT_TRUE(failed_ik_count == 0);
+  EXPECT_TRUE(failed_windup_count == 0);
+}
+}

--- a/moveit_simple/test/tool_windup.cpp
+++ b/moveit_simple/test/tool_windup.cpp
@@ -82,8 +82,11 @@ TEST(MoveitSimpleTest, test_limit_ik_windup)
   seed_fractions[5] = 0.3;
   EXPECT_TRUE(robot.setIKSeedStateFractions(seed_fractions));
   EXPECT_TRUE(seed_fractions == robot.getIKSeedStateFractions());
-  // enable joint windup limitation
-  robot.limitJointWindup(true);
+  // Test enable and disable joint windup limitation. (this should end with an enabled flag)
+  robot.setLimitJointWindup(false);
+  EXPECT_FALSE(robot.getLimitJointWindup());
+  robot.setLimitJointWindup(true);
+  EXPECT_TRUE(robot.getLimitJointWindup());
 
   // run same rotations as before and verify that windup is disabled
   pose.linear().setIdentity();

--- a/moveit_simple/test/tool_windup.cpp
+++ b/moveit_simple/test/tool_windup.cpp
@@ -47,61 +47,6 @@ using testing::Types;
 namespace moveit_simple_test
 {
 
-/**
- * @brief UserRobotTest is a fixture for testing public methods.
- * Objects that can be directly used inside the test
- - robot pointer for moveit_simple::OnlineRobot
-*/
-class UserRobotTest : public ::testing::Test
-{
-protected:
-  std::unique_ptr<moveit_simple::OnlineRobot> robot;
-  virtual void SetUp()
-  {
-  robot = std::unique_ptr<moveit_simple::OnlineRobot> (new moveit_simple::OnlineRobot
-                  (ros::NodeHandle(), "robot_description", "manipulator"));
-  ros::Duration(2.0).sleep();  //wait for tf tree to populate
-  }
-  virtual void TearDown()
-  {}
-};
-
-/**
- * @brief DeveloperRobot is a class inheriting from moveit_simple::OnlineRobot to test protected methods
- * Add the protected methods(that are required to be tested) in the following list
-*/
-class DeveloperRobot: public moveit_simple::OnlineRobot
-{
-public:
-  using moveit_simple::OnlineRobot::OnlineRobot;
-  using moveit_simple::OnlineRobot::addTrajPoint;
-  using moveit_simple::OnlineRobot::toJointTrajectory;
-  using moveit_simple::OnlineRobot::interpolate;
-  using moveit_simple::OnlineRobot::jointInterpolation;
-  using moveit_simple::OnlineRobot::cartesianInterpolation;
-  using moveit_simple::OnlineRobot::isInCollision;
-};
-
-/**
- * @brief DeveloperRobotTest is a fixture for testing protected methods.
- * Objects that can be directly used inside the test
- - robot pointer for DeveloperRobot
-*/
-
-class DeveloperRobotTest : public ::testing::Test
-{
-protected:
-  std::unique_ptr<DeveloperRobot> robot2;
-  virtual void SetUp()
-  {
-  robot2 = std::unique_ptr<DeveloperRobot> (new DeveloperRobot
-                  (ros::NodeHandle(), "robot_description", "manipulator"));
-  ros::Duration(2.0).sleep();  //wait for tf tree to populate
-  }
-  virtual void TearDown()
-  {}
-};
-
 TEST(MoveitSimpleTest, construction_robot)
 {
   moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");

--- a/moveit_simple/test/tool_windup.cpp
+++ b/moveit_simple/test/tool_windup.cpp
@@ -1,20 +1,40 @@
-/*
- * Software License Agreement (Apache License)
+/*********************************************************************
+ * Software License Agreement (BSD License)
  *
- * Copyright (c) 2019 Plus One Robotics
+ *  Copyright (c) 2019, PickNik LLC
+ *  All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Henning Kayser
+   Desc: Unit test cases for verifying tool windup limitation is functional
+*/
 
 #include <eigen_conversions/eigen_msg.h>
 #include <gtest/gtest.h>

--- a/moveit_simple/test/tool_windup_utest.cpp
+++ b/moveit_simple/test/tool_windup_utest.cpp
@@ -1,20 +1,40 @@
-/*
- * Software License Agreement (Apache License)
+/*********************************************************************
+ * Software License Agreement (BSD License)
  *
- * Copyright (c) 2019 Plus One Robotics
+ *  Copyright (c) 2019, PickNik LLC
+ *  All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Henning Kayser
+   Desc: Node for tool windup limitation unit tests (tool_windup.cpp)
+*/
 
 #include <gtest/gtest.h>
 #include <ros/ros.h>

--- a/moveit_simple/test/tool_windup_utest.cpp
+++ b/moveit_simple/test/tool_windup_utest.cpp
@@ -1,0 +1,34 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+#include <boost/thread/thread.hpp>
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "tool_windup_utest");
+  boost::thread ros_thread(boost::bind(&ros::spin));
+
+  int res = RUN_ALL_TESTS();
+  ros_thread.interrupt();
+  ros_thread.join();
+
+  return res;
+}

--- a/moveit_simple_msgs/package.xml
+++ b/moveit_simple_msgs/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="aaronwood@plusonerobotics.com">Aaron Wood</maintainer>
 
-  <license>Apache 2.0</license> <!-- moveit_simple_msgs --> 
+  <license>Apache 2.0</license> <!-- moveit_simple_msgs -->
   <license>Boost Software License</license> <!-- prettyprint -->
 
   <author email="aaronwood@plusonerobotics.com">Aaron Wood</author>


### PR DESCRIPTION
This is the first part on limiting joint windup for single IK solutions by setting a "soft" joint limit that still allows exceeding it intentionally. It's based on setting a joint value modifier in range [0,1] that is multiplied with the IK seed state to "pull" desired joints towards the center. This works best in combination with minimal-distance IK solvers (like currently LMA). To eliminate outliers completely the consistency limit of specified joints is set to the lower value PI.

This method allows to preserve the full freedom of the joint since only the seed state is modified.
This allows for consecutive IK solutions to still move the full way if the steps are sufficiently small (i.e. for cartesian planning). For example a value of 0.5 would allow the joint value to converge to 2*PI but only if sequential IK calls produce solutions within closest proximity. The closer the the value is to the limit the lower the distance needs to be to still move towards it. In practice this means that the actually reachable limit is considerably below that one. Lower fractions let the value converge to lower limits (I could make a table for that). A good value to limit wrist windup would be 0.3 or maybe even lower (~1.4*PI limit).

The modifiers are stored in a map `ik_seed_state_fractions_` and can only accessed by getter() and setter() functions that also test the validity of the values. The feature is enabled by calling `robot.limitJointWindup(true)` and is active for all `getJointSolution()` calls including waypoint conversions.

The test shows how this is applied to limit wrist joint windup by setting the corresponding fraction to 0.3.
I suggest specifying desired values either inside the `kinematics.yaml` or inside a new `moveit_simple.yaml` since I think this should be needed anyway.

This solution is meant to be used for all IK calls but does not support end effector symmetries.
For this a separate function will be needed anyway just as for separate pick/place state optimization.
I'm planning to do follow-up PRs for that so this one doesn't get bloated.